### PR TITLE
supply network representation with return data

### DIFF
--- a/MaxMind.Db/Reader.cs
+++ b/MaxMind.Db/Reader.cs
@@ -199,9 +199,12 @@ namespace MaxMind.Db
                 return null;
             }
 
-            IPAddress networkAddress = GetNetworkAddress(ipAddress, networkBitLength);
-            string network = string.Format("{0}/{1}", networkAddress, networkBitLength);
-            token["network"] = network;
+            if (token is JObject)
+            {
+                IPAddress networkAddress = GetNetworkAddress(ipAddress, networkBitLength);
+                string network = string.Format("{0}/{1}", networkAddress, networkBitLength);
+                ((JObject)token).Add("network", network);
+            }
 
             return token;
         }


### PR DESCRIPTION
With this change, the data returned from Find(IPAddress) will be updated with the address of the network, which was found to have the record For example: "network": "2c0f:fe98::/32", or "network": "1.21.106.0/24". I am suggesting this change in order to allow more efficient caching of the data, where the lookup queries are performed on the remote machine. This will allow recipient cache the whole network instead of just one address.