### PR TITLE
Abstract away data reading. Do not use streams.

### DIFF
--- a/MaxMind.Db.Test/DecoderTest.cs
+++ b/MaxMind.Db.Test/DecoderTest.cs
@@ -368,9 +368,9 @@ namespace MaxMind.Db.Test
                 var expect = entry.Key;
                 var input = entry.Value;
 
-                using (var stream = new ThreadLocal<Stream>(() => new MemoryStream(input)))
+                using (var database = new ArrayReader(input))
                 {
-                    var decoder = new Decoder(stream, 0) {PointerTestHack = true};
+                    var decoder = new Decoder(database, 0) {PointerTestHack = true};
                     var jToken = decoder.Decode(0).Node;
 
                     if (jToken is JRaw)

--- a/MaxMind.Db.Test/DecoderTest.cs
+++ b/MaxMind.Db.Test/DecoderTest.cs
@@ -2,10 +2,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Numerics;
 using System.Text;
-using System.Threading;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
@@ -283,9 +281,7 @@ namespace MaxMind.Db.Test
                 /* Foo */0x43, 0x46, 0x6f, 0x6f
             });
 
-            var two = new JObject();
-            two.Add("en", "Foo");
-            two.Add("zh", "人");
+            var two = new JObject {{"en", "Foo"}, {"zh", "人"}};
             maps.Add(two, new byte[]
             {
                 0xe2,

--- a/MaxMind.Db.Test/PointerTest.cs
+++ b/MaxMind.Db.Test/PointerTest.cs
@@ -15,10 +15,9 @@ namespace MaxMind.Db.Test
         public void TestWithPointers()
         {
             var path = Path.Combine("..", "..", "TestData", "MaxMind-DB", "test-data", "maps-with-pointers.raw");
-            var stream = new ThreadLocal<Stream>(() => new MemoryStream(File.ReadAllBytes(path)));
-            using (stream)
+            using (var database = new ArrayReader(path))
             {
-                var decoder = new Decoder(stream, 0);
+                var decoder = new Decoder(database, 0);
 
                 var node = decoder.Decode(0).Node;
                 Assert.That(node.Value<string>("long_key"), Is.EqualTo("long_value1"));

--- a/MaxMind.Db.Test/PointerTest.cs
+++ b/MaxMind.Db.Test/PointerTest.cs
@@ -1,7 +1,6 @@
 ﻿#region
 
 using System.IO;
-using System.Threading;
 using NUnit.Framework;
 
 #endregion

--- a/MaxMind.Db.Test/ReaderTest.cs
+++ b/MaxMind.Db.Test/ReaderTest.cs
@@ -15,7 +15,7 @@ namespace MaxMind.Db.Test
     [TestFixture]
     public class ReaderTest
     {
-        private readonly string TestDataRoot = Path.Combine("..", "..", "TestData", "MaxMind-DB", "test-data");
+        private readonly string _testDataRoot = Path.Combine("..", "..", "TestData", "MaxMind-DB", "test-data");
 
         [Test]
         public void Test()
@@ -24,7 +24,7 @@ namespace MaxMind.Db.Test
             {
                 foreach (var ipVersion in new[] {4, 6})
                 {
-                    var file = Path.Combine(TestDataRoot, "MaxMind-DB-test-ipv" + ipVersion + "-" + recordSize + ".mmdb");
+                    var file = Path.Combine(_testDataRoot, "MaxMind-DB-test-ipv" + ipVersion + "-" + recordSize + ".mmdb");
                     var reader = new Reader(file);
                     using (reader)
                     {
@@ -50,7 +50,7 @@ namespace MaxMind.Db.Test
             {
                 foreach (var ipVersion in new[] {4, 6})
                 {
-                    var file = Path.Combine(TestDataRoot, "MaxMind-DB-test-ipv" + ipVersion + "-" + recordSize + ".mmdb");
+                    var file = Path.Combine(_testDataRoot, "MaxMind-DB-test-ipv" + ipVersion + "-" + recordSize + ".mmdb");
                     using (var streamReader = new StreamReader(file))
                     {
                         using (var reader = new Reader(streamReader.BaseStream))
@@ -85,7 +85,7 @@ namespace MaxMind.Db.Test
         [Test]
         public void NoIPV4SearchTree()
         {
-            using (var reader = new Reader(Path.Combine(TestDataRoot, "MaxMind-DB-no-ipv4-search-tree.mmdb")))
+            using (var reader = new Reader(Path.Combine(_testDataRoot, "MaxMind-DB-no-ipv4-search-tree.mmdb")))
             {
                 Assert.That(reader.Find("1.1.1.1").ToObject<string>(), Is.EqualTo("::0/64"));
                 Assert.That(reader.Find("192.1.1.1").ToObject<string>(), Is.EqualTo("::0/64"));
@@ -95,7 +95,7 @@ namespace MaxMind.Db.Test
         [Test]
         public void TestDecodingTypes()
         {
-            using (var reader = new Reader(Path.Combine(TestDataRoot, "MaxMind-DB-test-decoder.mmdb")))
+            using (var reader = new Reader(Path.Combine(_testDataRoot, "MaxMind-DB-test-decoder.mmdb")))
             {
                 var record = reader.Find("::1.1.1.0");
 
@@ -141,7 +141,7 @@ namespace MaxMind.Db.Test
         [Test]
         public void TestZeros()
         {
-            using (var reader = new Reader(Path.Combine(TestDataRoot, "MaxMind-DB-test-decoder.mmdb")))
+            using (var reader = new Reader(Path.Combine(_testDataRoot, "MaxMind-DB-test-decoder.mmdb")))
             {
                 var record = reader.Find("::");
 
@@ -172,7 +172,7 @@ namespace MaxMind.Db.Test
             MatchType = MessageMatch.Contains)]
         public void TestBrokenDatabase()
         {
-            using (var reader = new Reader(Path.Combine(TestDataRoot, "GeoIP2-City-Test-Broken-Double-Format.mmdb")))
+            using (var reader = new Reader(Path.Combine(_testDataRoot, "GeoIP2-City-Test-Broken-Double-Format.mmdb")))
             {
                 reader.Find("2001:220::");
             }
@@ -183,7 +183,7 @@ namespace MaxMind.Db.Test
             MatchType = MessageMatch.Contains)]
         public void TestBrokenSearchTreePointer()
         {
-            using (var reader = new Reader(Path.Combine(TestDataRoot, "MaxMind-DB-test-broken-pointers-24.mmdb")))
+            using (var reader = new Reader(Path.Combine(_testDataRoot, "MaxMind-DB-test-broken-pointers-24.mmdb")))
             {
                 reader.Find("1.1.1.32");
             }
@@ -194,7 +194,7 @@ namespace MaxMind.Db.Test
             MatchType = MessageMatch.Contains)]
         public void TestBrokenDataPointer()
         {
-            using (var reader = new Reader(Path.Combine(TestDataRoot, "MaxMind-DB-test-broken-pointers-24.mmdb")))
+            using (var reader = new Reader(Path.Combine(_testDataRoot, "MaxMind-DB-test-broken-pointers-24.mmdb")))
             {
                 reader.Find("1.1.1.16");
             }
@@ -244,19 +244,19 @@ namespace MaxMind.Db.Test
             foreach (var address in singleAddresses)
             {
                 Assert.That(reader.Find(address).Value<string>("ip"), Is.EqualTo(address),
-                    string.Format("Did not find expected data record for {0} in {1}", address, file));
+                    $"Did not find expected data record for {address} in {file}");
             }
 
             foreach (var address in pairs.Keys)
             {
                 Assert.That(reader.Find(address).Value<string>("ip"), Is.EqualTo(pairs[address]),
-                    string.Format("Did not find expected data record for {0} in {1}", address, file));
+                    $"Did not find expected data record for {address} in {file}");
             }
 
             foreach (var address in nullAddresses)
             {
                 Assert.That(reader.Find(address), Is.Null,
-                    string.Format("Did not find expected data record for {0} in {1}", address, file));
+                    $"Did not find expected data record for {address} in {file}");
             }
         }
 

--- a/MaxMind.Db.Test/ThreadingTest.cs
+++ b/MaxMind.Db.Test/ThreadingTest.cs
@@ -44,8 +44,7 @@ namespace MaxMind.Db.Test
                     var resultString = result.ToString();
                     var expectedString = ipsAndResults[ipAddress];
                     if (resultString != expectedString)
-                        throw new Exception(string.Format("Non-matching result. Expected {0}, found {1}", expectedString,
-                            resultString));
+                        throw new Exception($"Non-matching result. Expected {expectedString}, found {resultString}");
                 });
             }
         }

--- a/MaxMind.Db.Test/packages.config
+++ b/MaxMind.Db.Test/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+
 <packages>
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net4" userInstalled="true" />
   <package id="NUnit" version="2.6.4" targetFramework="net4" userInstalled="true" />

--- a/MaxMind.Db.sln
+++ b/MaxMind.Db.sln
@@ -1,8 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
-MinimumVisualStudioVersion = 10.0.40219.1
+VisualStudioVersion = 14.0.22823.1
+MinimumVisualStudioVersion = 14.0.22823.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MaxMind.Db", "MaxMind.Db\MaxMind.Db.csproj", "{7600F6BC-DE08-4253-B0B0-35C80ED72CF2}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MaxMind.Db.Benchmark", "MaxMind.Db.Benchmark\MaxMind.Db.Benchmark.csproj", "{B9B6E140-C381-4C8B-A41E-117FDAA14F35}"

--- a/MaxMind.Db.sln
+++ b/MaxMind.Db.sln
@@ -1,6 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
+# Visual Studio 2015
 VisualStudioVersion = 14.0.22823.1
 MinimumVisualStudioVersion = 14.0.22823.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MaxMind.Db", "MaxMind.Db\MaxMind.Db.csproj", "{7600F6BC-DE08-4253-B0B0-35C80ED72CF2}"

--- a/MaxMind.Db/ArrayReader.cs
+++ b/MaxMind.Db/ArrayReader.cs
@@ -1,16 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 
 namespace MaxMind.Db
 {
     internal class ArrayReader : IByteReader
     {
         private readonly byte[] _fileBytes;
-
-        public int Length => _fileBytes.Length;
 
         public ArrayReader(string file)
         {
@@ -21,6 +16,8 @@ namespace MaxMind.Db
         {
             _fileBytes = array;
         }
+
+        public int Length => _fileBytes.Length;
 
         public byte[] Read(int offset, int count)
         {
@@ -44,7 +41,6 @@ namespace MaxMind.Db
 
         public void Dispose()
         {
-            /// ??
         }
     }
 }

--- a/MaxMind.Db/ArrayReader.cs
+++ b/MaxMind.Db/ArrayReader.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace MaxMind.Db
+{
+    internal class ArrayReader : IByteReader
+    {
+        private readonly byte[] _fileBytes;
+
+        public int Length => _fileBytes.Length;
+
+        public ArrayReader(string file)
+        {
+            _fileBytes = File.ReadAllBytes(file);
+        }
+
+        public ArrayReader(byte[] array)
+        {
+            _fileBytes = array;
+        }
+
+        public byte[] Read(int offset, int count)
+        {
+            // Not using an ArraySegment as you can cast it into an IList
+            // in .NET 4. I also looked into ImmutableArray, but it appears
+            // that it does a copy when creating a subarray.
+            var bytes = new byte[count];
+            Copy(offset, bytes);
+            return bytes;
+        }
+
+        public byte ReadOne(int offset) => _fileBytes[offset];
+
+        public void Copy(int offset, byte[] bytes)
+        {
+            if (bytes.Length > 0)
+            {
+                Array.Copy(_fileBytes, offset, bytes, 0, bytes.Length);
+            }
+        }
+
+        public void Dispose()
+        {
+            /// ??
+        }
+    }
+}

--- a/MaxMind.Db/Decoder.cs
+++ b/MaxMind.Db/Decoder.cs
@@ -1,11 +1,9 @@
 ﻿#region
 
 using System;
-using System.IO;
 using System.Linq;
 using System.Numerics;
 using System.Text;
-using System.Threading;
 using Newtonsoft.Json.Linq;
 
 #endregion
@@ -41,16 +39,6 @@ namespace MaxMind.Db
     internal class Result
     {
         /// <summary>
-        ///     The object read from the database
-        /// </summary>
-        internal JToken Node { get; set; }
-
-        /// <summary>
-        ///     The offset
-        /// </summary>
-        internal int Offset { get; set; }
-
-        /// <summary>
         ///     Initializes a new instance of the <see cref="Result" /> class.
         /// </summary>
         /// <param name="node">The node.</param>
@@ -60,6 +48,16 @@ namespace MaxMind.Db
             Node = node;
             Offset = offset;
         }
+
+        /// <summary>
+        ///     The object read from the database
+        /// </summary>
+        internal JToken Node { get; set; }
+
+        /// <summary>
+        ///     The offset
+        /// </summary>
+        internal int Offset { get; set; }
     }
 
     /// <summary>
@@ -68,23 +66,21 @@ namespace MaxMind.Db
     internal class Decoder
     {
         private readonly IByteReader _database;
-
         private readonly int _pointerBase;
-
         private readonly int[] _pointerValueOffset = {0, 0, 1 << 11, (1 << 19) + ((1) << 11), 0};
-
-        internal bool PointerTestHack { get; set; }
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="Decoder" /> class.
         /// </summary>
-        /// <param name="stream">The stream.</param>
+        /// <param name="database">The database.</param>
         /// <param name="pointerBase">The base address in the stream.</param>
         internal Decoder(IByteReader database, int pointerBase)
         {
             _pointerBase = pointerBase;
             _database = database;
         }
+
+        internal bool PointerTestHack { get; set; }
 
         /// <summary>
         ///     Decodes the object at the specified offset.
@@ -311,7 +307,7 @@ namespace MaxMind.Db
         /// <returns></returns>
         private JValue DecodeLong(byte[] buffer)
         {
-            long integer = buffer.Aggregate<byte, long>(0, (current, t) => (current << 8) | t);
+            var integer = buffer.Aggregate<byte, long>(0, (current, t) => (current << 8) | t);
             return new JValue(integer);
         }
 
@@ -352,7 +348,7 @@ namespace MaxMind.Db
         /// <returns></returns>
         private JValue DecodeUInt64(byte[] buffer)
         {
-            ulong integer = buffer.Aggregate<byte, ulong>(0, (current, t) => (current << 8) | t);
+            var integer = buffer.Aggregate<byte, ulong>(0, (current, t) => (current << 8) | t);
             return new JValue(integer);
         }
 

--- a/MaxMind.Db/IByteReader.cs
+++ b/MaxMind.Db/IByteReader.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MaxMind.Db
+{
+    internal interface IByteReader: IDisposable
+    {
+        int Length { get; }
+
+        byte[] Read(int offset, int count);
+        byte ReadOne(int offset);
+
+        void Copy(int offset, byte[] array);
+    }
+}

--- a/MaxMind.Db/IByteReader.cs
+++ b/MaxMind.Db/IByteReader.cs
@@ -1,17 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace MaxMind.Db
 {
-    internal interface IByteReader: IDisposable
+    internal interface IByteReader : IDisposable
     {
         int Length { get; }
-
         byte[] Read(int offset, int count);
         byte ReadOne(int offset);
-
         void Copy(int offset, byte[] array);
     }
 }

--- a/MaxMind.Db/MaxMind.Db.csproj
+++ b/MaxMind.Db/MaxMind.Db.csproj
@@ -53,6 +53,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\MaxMind.Db.xml</DocumentationFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>
@@ -92,7 +93,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Decoder.cs" />
+    <Compile Include="ArrayReader.cs" />
+    <Compile Include="IByteReader.cs" />
     <Compile Include="InvalidDatabaseException.cs" />
+    <Compile Include="MemoryMapReader.cs" />
     <Compile Include="Reader.cs" />
     <Compile Include="Metadata.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/MaxMind.Db/MaxMind.Db.csproj
+++ b/MaxMind.Db/MaxMind.Db.csproj
@@ -54,6 +54,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\MaxMind.Db.xml</DocumentationFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>

--- a/MaxMind.Db/MemoryMapReader.cs
+++ b/MaxMind.Db/MemoryMapReader.cs
@@ -9,6 +9,7 @@ namespace MaxMind.Db
         private static readonly object FileLocker = new object();
         private readonly MemoryMappedFile _memoryMappedFile;
         private readonly MemoryMappedViewAccessor _view;
+        private bool _disposed;
 
         public MemoryMapReader(string file)
         {
@@ -57,10 +58,31 @@ namespace MaxMind.Db
             _view.ReadArray(offset, bytes, 0, bytes.Length);
         }
 
+        /// <summary>
+        ///     Release resources back to the system.
+        /// </summary>
         public void Dispose()
         {
-            _view.Dispose();
-            _memoryMappedFile.Dispose();
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        ///     Release resources back to the system.
+        /// </summary>
+        /// <param name="disposing"></param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+                return;
+
+            if (disposing)
+            {
+                _view.Dispose();
+                _memoryMappedFile.Dispose();
+            }
+
+            _disposed = true;
         }
     }
 }

--- a/MaxMind.Db/MemoryMapReader.cs
+++ b/MaxMind.Db/MemoryMapReader.cs
@@ -52,9 +52,10 @@ namespace MaxMind.Db
 
         public void Copy(int offset, byte[] bytes)
         {
-            // Doing an unsafe read improves performance by 10%. Probably
-            // not worth the increased support overhead from people asking
-            // why we use unsafe.
+            // Although not explicitly marked as thread safe, from
+            // reviewing the source code, these operations appear to
+            // be thread safe as long as only read operations are
+            // being done.
             _view.ReadArray(offset, bytes, 0, bytes.Length);
         }
 

--- a/MaxMind.Db/MemoryMapReader.cs
+++ b/MaxMind.Db/MemoryMapReader.cs
@@ -24,15 +24,10 @@ namespace MaxMind.Db
                 {
                     _memoryMappedFile = MemoryMappedFile.OpenExisting(mmfName, MemoryMappedFileRights.Read);
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is IOException || ex is NotImplementedException)
                 {
-                    if (ex is IOException || ex is NotImplementedException)
-                    {
-                        _memoryMappedFile = MemoryMappedFile.CreateFromFile(file, FileMode.Open,
+                    _memoryMappedFile = MemoryMappedFile.CreateFromFile(file, FileMode.Open,
                             mmfName, fileInfo.Length, MemoryMappedFileAccess.Read);
-                    }
-                    else
-                        throw;
                 }
             }
 

--- a/MaxMind.Db/MemoryMapReader.cs
+++ b/MaxMind.Db/MemoryMapReader.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.IO.MemoryMappedFiles;
-using System.Runtime.InteropServices;
 
 namespace MaxMind.Db
 {
@@ -11,8 +9,6 @@ namespace MaxMind.Db
         private static readonly object FileLocker = new object();
         private readonly MemoryMappedFile _memoryMappedFile;
         private readonly MemoryMappedViewAccessor _view;
-
-        public int Length { get; }
 
         public MemoryMapReader(string file)
         {
@@ -41,6 +37,8 @@ namespace MaxMind.Db
 
             _view = _memoryMappedFile.CreateViewAccessor(0, Length, MemoryMappedFileAccess.Read);
         }
+
+        public int Length { get; }
 
         public byte[] Read(int offset, int count)
         {

--- a/MaxMind.Db/MemoryMapReader.cs
+++ b/MaxMind.Db/MemoryMapReader.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.MemoryMappedFiles;
+using System.Runtime.InteropServices;
+
+namespace MaxMind.Db
+{
+    internal class MemoryMapReader : IByteReader
+    {
+        private static readonly object FileLocker = new object();
+        private readonly MemoryMappedFile _memoryMappedFile;
+        private readonly MemoryMappedViewAccessor _view;
+
+        public int Length { get; }
+
+        public MemoryMapReader(string file)
+        {
+            var fileInfo = new FileInfo(file);
+
+            Length = (int) fileInfo.Length;
+
+            var mmfName = fileInfo.FullName.Replace("\\", "-");
+            lock (FileLocker)
+            {
+                try
+                {
+                    _memoryMappedFile = MemoryMappedFile.OpenExisting(mmfName, MemoryMappedFileRights.Read);
+                }
+                catch (Exception ex)
+                {
+                    if (ex is IOException || ex is NotImplementedException)
+                    {
+                        _memoryMappedFile = MemoryMappedFile.CreateFromFile(file, FileMode.Open,
+                            mmfName, fileInfo.Length, MemoryMappedFileAccess.Read);
+                    }
+                    else
+                        throw;
+                }
+            }
+
+            _view = _memoryMappedFile.CreateViewAccessor(0, Length, MemoryMappedFileAccess.Read);
+        }
+
+        public byte[] Read(int offset, int count)
+        {
+            var bytes = new byte[count];
+            Copy(offset, bytes);
+            return bytes;
+        }
+
+        public byte ReadOne(int offset) => _view.ReadByte(offset);
+
+        public void Copy(int offset, byte[] bytes)
+        {
+            // Doing an unsafe read improves performance by 10%. Probably
+            // not worth the increased support overhead from people asking
+            // why we use unsafe.
+            _view.ReadArray(offset, bytes, 0, bytes.Length);
+        }
+
+        public void Dispose()
+        {
+            _view.Dispose();
+            _memoryMappedFile.Dispose();
+        }
+    }
+}

--- a/MaxMind.Db/Metadata.cs
+++ b/MaxMind.Db/Metadata.cs
@@ -34,10 +34,7 @@ namespace MaxMind.Db
         ///     The date-time of the database build.
         /// </summary>
         [JsonIgnore]
-        public DateTime BuildDate
-        {
-            get { return new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(BuildEpoch); }
-        }
+        public DateTime BuildDate => new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds(BuildEpoch);
 
         /// <summary>
         ///     The MaxMind DB database type.
@@ -70,14 +67,8 @@ namespace MaxMind.Db
         internal int RecordSize { get; set; }
 
         [JsonIgnore]
-        internal int NodeByteSize
-        {
-            get { return RecordSize/4; }
-        }
+        internal int NodeByteSize => RecordSize/4;
 
-        internal int SearchTreeSize
-        {
-            get { return NodeCount*NodeByteSize; }
-        }
+        internal int SearchTreeSize => NodeCount*NodeByteSize;
     }
 }

--- a/MaxMind.Db/Reader.cs
+++ b/MaxMind.Db/Reader.cs
@@ -283,10 +283,7 @@ namespace MaxMind.Db
         /// </summary>
         public void Dispose()
         {
-            // XXXXXXXXXXXX- todo
-//            _stream.Dispose();
-//            if (_memoryMappedFile != null)
-//                _memoryMappedFile.Dispose();
+            _database.Dispose();
         }
     }
 }

--- a/MaxMind.Db/Reader.cs
+++ b/MaxMind.Db/Reader.cs
@@ -42,6 +42,7 @@ namespace MaxMind.Db
             109
         };
 
+        private bool _disposed;
         private int _ipV4Start;
 
         /// <summary>
@@ -133,7 +134,25 @@ namespace MaxMind.Db
         /// </summary>
         public void Dispose()
         {
-            _database.Dispose();
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        ///     Release resources back to the system.
+        /// </summary>
+        /// <param name="disposing"></param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+                return;
+
+            if (disposing)
+            {
+                _database.Dispose();
+            }
+
+            _disposed = true;
         }
 
         private void InitMetaData()

--- a/MaxMind.Db/packages.config
+++ b/MaxMind.Db/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+
 <packages>
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net4" userInstalled="true" />
 </packages>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,20 @@
+version: 1.0.{build}
+
+os: Visual Studio 2015 RC
+
+before_build:
+  - nuget restore -verbosity detailed
+  - git submodule update --init --recursive
+
 install:
- - git submodule update --init --recursive
+- set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;%PATH%
+
+build:
+  verbosity: minimal
 
 notifications:
-  - provider: HipChat
-    auth_token:
-      secure: NtKXu/kGk8Td4YqCH95camAcNQtB3rMll+5DALAmbDY=
-    room: dev
+- provider: Email
+  to: dev@maxmind.com
+  on_build_success: false
+  on_build_failure: true
+  on_build_status_changed: true


### PR DESCRIPTION
This provides a significant performance boost and simplifies the code somewhat. It should also fix the ThreadLocal issues like the one reported in #5.