### PR TITLE
Use the :new: C# container from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,93 +1,37 @@
 ---
-language: generic
-
-addons:
-  apt:
-    packages:
-    - gettext
-    - libcurl4-openssl-dev
-    - libicu-dev
-    - libssl-dev
-    - libunwind8
-    - zlib1g
+language: csharp
+solution: mono/MaxMind.Db.Mono.sln
 
 env:
   global:
-    - MAXMIND_BENCHMARK_DB=MaxMind.Db.Benchmark/GeoLite2-City.mmdb
-    - MAXMIND_TEST_BASE_DIR=MaxMind.Db.Test
+    - MAXMIND_BENCHMARK_DB=$TRAVIS_BUILD_DIR/MaxMind.Db.Benchmark/GeoLite2-City.mmdb
+    - MAXMIND_TEST_BASE_DIR=$TRAVIS_BUILD_DIR/MaxMind.Db.Test
+    - CONFIGURATION=Release
 
 matrix:
   include:
-    - os: linux
-      dist: trusty # Ubuntu 14.04
-      sudo: required
-      env: CONFIGURATION=Debug
-    - os: linux
-      dist: trusty
-      sudo: required
-      env: CONFIGURATION=Release
-    - os: osx
-      osx_image: xcode7.2 # macOS 10.11
-      env: CONFIGURATION=Debug
-    - os: osx
-      osx_image: xcode7.2
-      env: CONFIGURATION=Release
+  - os: linux
+    dist: trusty # Ubuntu 14.04
+    dotnet: 1.0.0-preview2-003121
+    mono: none
+    env: DOTNETCORE=1
+    sudo: required
+  - os: osx
+    osx_image: xcode7.3 # macOS 10.11
+    dotnet: 1.0.0-preview2-003121
+    mono: none
+    env: DOTNETCORE=1
+  - os: linux
+    dist: trusty # Ubuntu 14.04
+    mono: latest
+    sudo: false
+  - os: osx
+    osx_image: xcode7.3 # macOS 10.11
+    mono: latest
 
-before_install:
-  # Install OpenSSL
-  # Also set download URLs obtained from https://www.microsoft.com/net/download#core
-  - if test "$TRAVIS_OS_NAME" == "osx"; then
-      brew install openssl;
-      brew link --force openssl;
-      export DOTNET_SDK_URL="https://go.microsoft.com/fwlink/?LinkID=809128";
-    else
-      export DOTNET_SDK_URL="https://go.microsoft.com/fwlink/?LinkID=809129";
-    fi
+install: git submodule update --init --recursive
 
-  - export DOTNET_INSTALL_DIR="$PWD/.dotnetcli"
-
-  # Install .NET CLI
-  - mkdir $DOTNET_INSTALL_DIR
-  - curl -L $DOTNET_SDK_URL -o dotnet_package
-  - tar -xvzf dotnet_package -C $DOTNET_INSTALL_DIR
-
-  # Add dotnet to PATH
-  - export PATH="$DOTNET_INSTALL_DIR:$PATH"
-
-  # Update submodules
-  - git submodule update --init --recursive
-
-install:
-  # Display dotnet version info
-  - which dotnet;
-    if [ $? -eq 0 ]; then
-      echo "Using dotnet:";
-      dotnet --info;
-    else
-      echo "dotnet.exe not found"
-      exit 1;
-    fi
-
-  # Hack for: https://github.com/dotnet/cli/issues/3658
-  - if test "$TRAVIS_OS_NAME" == "linux"; then
-      nvm install stable && nvm use stable;
-    fi
-  - node -e "jsonPath='./MaxMind.Db.Benchmark/project.json';data=require(jsonPath);fs=require('fs');delete data.frameworks.net45;fs.writeFileSync(jsonPath, JSON.stringify(data, null, 2))"
-
-  # Restore Packages
-  - dotnet restore
-
-  # Build Projects
-  - dotnet build -c $CONFIGURATION -f netstandard1.4 ./MaxMind.Db
-  - dotnet build -c $CONFIGURATION -f netcoreapp1.0 ./MaxMind.Db.Benchmark
-  - dotnet build -c $CONFIGURATION -f netcoreapp1.0 ./MaxMind.Db.Test
-
-script:
-  # Run Benchmark
-  - dotnet run -f netcoreapp1.0 -c $CONFIGURATION -p MaxMind.Db.Benchmark
-
-  # Run Unit Tests
-  - dotnet test -f netcoreapp1.0 -c $CONFIGURATION MaxMind.Db.Test
+script: ./dev-bin/build.sh
 
 notifications:
   email:

--- a/MaxMind.Db.Test/project.json
+++ b/MaxMind.Db.Test/project.json
@@ -11,7 +11,7 @@
       "target": "project"
     },
     "NUnit": "3.4.0",
-    "dotnet-test-nunit": "3.4.0-beta-1",
+    "dotnet-test-nunit": "3.4.0-beta-2",
   },
 
   "testRunner": "nunit",

--- a/dev-bin/build.sh
+++ b/dev-bin/build.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+cd `dirname $0`/..
+
+if [ -n "$DOTNETCORE" ]; then
+
+  echo Using .NET CLI
+
+  dotnet restore
+
+  # Building the dependent projects such as MaxMind.Db.Benchmark
+  # and MaxMind.Db.Test will build the MaxMind.Db lib; no need to
+  # build it explicitly (with dotnet-build command).
+
+  # Running Benchmark
+  dotnet run -f netcoreapp1.0 -c $CONFIGURATION -p ./MaxMind.Db.Benchmark
+
+  # Running Unit Tests
+  dotnet test -f netcoreapp1.0 -c $CONFIGURATION ./MaxMind.Db.Test
+
+else
+
+  echo Using Mono
+
+  cd mono
+
+  nuget restore
+
+  xbuild /p:Configuration=$CONFIGURATION
+
+  mono ../mono/packages/NUnit.ConsoleRunner.3.4.1/tools/nunit3-console.exe --where "cat != BreaksMono" ./bin/$CONFIGURATION/MaxMind.Db.Test.dll
+
+fi

--- a/mono/MaxMind.Db.Benchmark.csproj
+++ b/mono/MaxMind.Db.Benchmark.csproj
@@ -1,0 +1,96 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>9.0.30729</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{B9B6E140-C381-4C8B-A41E-117FDAA14F35}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MaxMind.Db.Benchmark</RootNamespace>
+    <AssemblyName>MaxMind.Db.Benchmark</AssemblyName>
+    <RootNamespace>MaxMind.Db.Benchmark</RootNamespace>
+    <AssemblyName>MaxMind.Db.Benchmark</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>3.5</OldToolsVersion>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core">
+      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="System.Xml.Linq">
+      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="System.Data.DataSetExtensions">
+      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\MaxMind.Db.Benchmark\Program.cs" />
+    <Compile Include="..\MaxMind.Db.Benchmark\Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="MaxMind.Db.csproj">
+      <Project>{7600F6BC-DE08-4253-B0B0-35C80ED72CF2}</Project>
+      <Name>MaxMind.Db</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/mono/MaxMind.Db.Mono.sln
+++ b/mono/MaxMind.Db.Mono.sln
@@ -1,0 +1,52 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MaxMind.Db", "MaxMind.Db.csproj", "{7600F6BC-DE08-4253-B0B0-35C80ED72CF2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MaxMind.Db.Benchmark", "MaxMind.Db.Benchmark.csproj", "{B9B6E140-C381-4C8B-A41E-117FDAA14F35}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MaxMind.Db.Test", "MaxMind.Db.Test.csproj", "{9EAC0AC7-1F72-4F43-9EAF-7DA00CBD4159}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7600F6BC-DE08-4253-B0B0-35C80ED72CF2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7600F6BC-DE08-4253-B0B0-35C80ED72CF2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7600F6BC-DE08-4253-B0B0-35C80ED72CF2}.Debug|x86.ActiveCfg = Debug|x86
+		{7600F6BC-DE08-4253-B0B0-35C80ED72CF2}.Debug|x86.Build.0 = Debug|x86
+		{7600F6BC-DE08-4253-B0B0-35C80ED72CF2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7600F6BC-DE08-4253-B0B0-35C80ED72CF2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7600F6BC-DE08-4253-B0B0-35C80ED72CF2}.Release|x86.ActiveCfg = Release|x86
+		{7600F6BC-DE08-4253-B0B0-35C80ED72CF2}.Release|x86.Build.0 = Release|x86
+		{B9B6E140-C381-4C8B-A41E-117FDAA14F35}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B9B6E140-C381-4C8B-A41E-117FDAA14F35}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B9B6E140-C381-4C8B-A41E-117FDAA14F35}.Debug|x86.ActiveCfg = Debug|x86
+		{B9B6E140-C381-4C8B-A41E-117FDAA14F35}.Debug|x86.Build.0 = Debug|x86
+		{B9B6E140-C381-4C8B-A41E-117FDAA14F35}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B9B6E140-C381-4C8B-A41E-117FDAA14F35}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B9B6E140-C381-4C8B-A41E-117FDAA14F35}.Release|x86.ActiveCfg = Release|x86
+		{B9B6E140-C381-4C8B-A41E-117FDAA14F35}.Release|x86.Build.0 = Release|x86
+		{9EAC0AC7-1F72-4F43-9EAF-7DA00CBD4159}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9EAC0AC7-1F72-4F43-9EAF-7DA00CBD4159}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9EAC0AC7-1F72-4F43-9EAF-7DA00CBD4159}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9EAC0AC7-1F72-4F43-9EAF-7DA00CBD4159}.Debug|x86.Build.0 = Debug|Any CPU
+		{9EAC0AC7-1F72-4F43-9EAF-7DA00CBD4159}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9EAC0AC7-1F72-4F43-9EAF-7DA00CBD4159}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9EAC0AC7-1F72-4F43-9EAF-7DA00CBD4159}.Release|x86.ActiveCfg = Release|Any CPU
+		{9EAC0AC7-1F72-4F43-9EAF-7DA00CBD4159}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(SubversionScc) = preSolution
+		Svn-Managed = True
+		Manager = AnkhSVN - Subversion Support for Visual Studio
+	EndGlobalSection
+EndGlobal

--- a/mono/MaxMind.Db.Test.csproj
+++ b/mono/MaxMind.Db.Test.csproj
@@ -1,0 +1,86 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{9EAC0AC7-1F72-4F43-9EAF-7DA00CBD4159}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MaxMind.Db.Test</RootNamespace>
+    <AssemblyName>MaxMind.Db.Test</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\MaxMind.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework, Version=3.4.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>packages\NUnit.3.4.0\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\MaxMind.Db.Test\DecoderTest.cs" />
+    <Compile Include="..\MaxMind.Db.Test\Helper\TestUtils.cs" />
+    <Compile Include="..\MaxMind.Db.Test\Helper\TypeHolder.cs" />
+    <Compile Include="..\MaxMind.Db.Test\PointerTest.cs" />
+    <Compile Include="..\MaxMind.Db.Test\Properties\AssemblyInfo.cs" />
+    <Compile Include="..\MaxMind.Db.Test\ReaderTest.cs" />
+    <Compile Include="..\MaxMind.Db.Test\ThreadingTest.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="MaxMind.Db.csproj">
+      <Project>{7600f6bc-de08-4253-b0b0-35c80ed72cf2}</Project>
+      <Name>MaxMind.Db</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/mono/MaxMind.Db.csproj
+++ b/mono/MaxMind.Db.csproj
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>9.0.30729</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{7600F6BC-DE08-4253-B0B0-35C80ED72CF2}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MaxMind.Db</RootNamespace>
+    <AssemblyName>MaxMind.Db</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>3.5</OldToolsVersion>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>MaxMind.Db.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\MaxMind.Db.xml</DocumentationFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <CodeAnalysisRuleSet>MaxMind.Db.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CodeAnalysisRuleSet>MaxMind.Db.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MaxMind.Db.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\MaxMind.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System" />
+    <Reference Include="System.Core">
+      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Xml.Linq">
+      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="System.Data.DataSetExtensions">
+      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\MaxMind.Db\ByteArrayEqualityComparer.cs" />
+    <Compile Include="..\MaxMind.Db\Decoder.cs" />
+    <Compile Include="..\MaxMind.Db\ArrayBuffer.cs" />
+    <Compile Include="..\MaxMind.Db\DeserializationException.cs" />
+    <Compile Include="..\MaxMind.Db\Buffer.cs" />
+    <Compile Include="..\MaxMind.Db\DictionaryActivatorCreator.cs" />
+    <Compile Include="..\MaxMind.Db\GlobalSuppressions.cs" />
+    <Compile Include="..\MaxMind.Db\InjectableValues.cs" />
+    <Compile Include="..\MaxMind.Db\InvalidDatabaseException.cs" />
+    <Compile Include="..\MaxMind.Db\ListActivatorCreator.cs" />
+    <Compile Include="..\MaxMind.Db\ConstructorAttribute.cs" />
+    <Compile Include="..\MaxMind.Db\InjectAttribute.cs" />
+    <Compile Include="..\MaxMind.Db\ParameterAttribute.cs" />
+    <Compile Include="..\MaxMind.Db\MemoryMapBuffer.cs" />
+    <Compile Include="..\MaxMind.Db\Reader.cs" />
+    <Compile Include="..\MaxMind.Db\Metadata.cs" />
+    <Compile Include="..\MaxMind.Db\Properties\AssemblyInfo.cs" />
+    <Compile Include="..\MaxMind.Db\ReflectionUtil.cs" />
+    <Compile Include="..\MaxMind.Db\TypeAcivatorCreator.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="../MaxMind.Db/MaxMind.Db.ruleset" />
+  </ItemGroup>
+  <ItemGroup>
+    <CodeAnalysisDictionary Include="../MaxMind.Db/CustomDictionary.xml" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/mono/packages.config
+++ b/mono/packages.config
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="3.4.0" targetFramework="net45" />
+  <package id="NUnit.ConsoleRunner" version="3.4.1" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
* Updated `travis.yml` to use new container for `language: csharp`, which
  offers `dotnet`, `mono` or both runtimes.
* Added mono directory with separate sln targeting `csproj` and
  `packages.config` files.
* Removed the node.js hack.
* Extracted out `build.sh` file in `dev-bin` directory to standarise
  the CI script