### PR TITLE
Optimize ArrayBuffer BytesFromStream

### DIFF
--- a/MaxMind.Db.Test/Helper/NonSeekableStreamWrapper.cs
+++ b/MaxMind.Db.Test/Helper/NonSeekableStreamWrapper.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.IO;
+
+namespace MaxMind.Db.Test.Helper
+{
+    internal class NonSeekableStreamWrapper
+        : Stream
+    {
+        private readonly Stream _wrappedStream;
+
+        public NonSeekableStreamWrapper(Stream wrappedStream)
+        {
+            _wrappedStream = wrappedStream;
+        }
+        
+        public override void Flush()
+        {
+            _wrappedStream.Flush();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return _wrappedStream.Read(buffer, offset, count);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            _wrappedStream.Write(buffer, offset, count);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            _wrappedStream.Dispose();
+        }
+
+        public override bool CanRead => _wrappedStream.CanRead;
+        public override bool CanSeek =>false;
+        public override bool CanWrite => _wrappedStream.CanWrite;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+    }
+}

--- a/MaxMind.Db.Test/ReaderTest.cs
+++ b/MaxMind.Db.Test/ReaderTest.cs
@@ -78,6 +78,36 @@ namespace MaxMind.Db.Test
         }
 
         [Fact]
+        public void TestNonSeekableStream()
+        {
+            foreach (var recordSize in new long[] { 24, 28, 32 })
+            {
+                foreach (var ipVersion in new[] { 4, 6 })
+                {
+                    var file = Path.Combine(_testDataRoot,
+                        "MaxMind-DB-test-ipv" + ipVersion + "-" + recordSize + ".mmdb");
+                    
+                    using (var stream = new NonSeekableStreamWrapper(File.OpenRead(file)))
+                    {
+                        using (var reader = new Reader(stream))
+                        {
+                            TestMetadata(reader, ipVersion);
+
+                            if (ipVersion == 4)
+                            {
+                                TestIPV4(reader, file);
+                            }
+                            else
+                            {
+                                TestIPV6(reader, file);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        [Fact]
         public void NullStreamThrowsArgumentNullException()
         {
             ((Action)(() => new Reader((Stream)null)))

--- a/MaxMind.Db/ArrayBuffer.cs
+++ b/MaxMind.Db/ArrayBuffer.cs
@@ -31,8 +31,18 @@ namespace MaxMind.Db
             {
                 throw new ArgumentNullException(nameof(stream), "The database stream must not be null.");
             }
-            byte[] bytes;
 
+            byte[] bytes;
+            
+            // If the stream is within "int" max size, we can read it at once without requiring MemoryStream
+            if (stream.CanSeek && stream.Length <= int.MaxValue)
+            {
+                bytes = new byte[stream.Length];
+                stream.Read(bytes, 0, (int)stream.Length);
+                return bytes;
+            }
+
+            // Else, use MemoryStream
             using (var memoryStream = new MemoryStream())
             {
                 stream.CopyTo(memoryStream);
@@ -44,6 +54,7 @@ namespace MaxMind.Db
                 throw new InvalidDatabaseException(
                     "There are zero bytes left in the stream. Perhaps you need to reset the stream's position.");
             }
+            
             return bytes;
         }
 

--- a/MaxMind.Db/ArrayBuffer.cs
+++ b/MaxMind.Db/ArrayBuffer.cs
@@ -38,15 +38,16 @@ namespace MaxMind.Db
             if (stream.CanSeek && stream.Length <= int.MaxValue)
             {
                 bytes = new byte[stream.Length];
-                stream.Read(bytes, 0, (int)stream.Length);
-                return bytes;
+                stream.Read(bytes, 0, (int) stream.Length);
             }
-
-            // Else, use MemoryStream
-            using (var memoryStream = new MemoryStream())
+            else
             {
-                stream.CopyTo(memoryStream);
-                bytes = memoryStream.ToArray();
+                // Else, use MemoryStream
+                using (var memoryStream = new MemoryStream())
+                {
+                    stream.CopyTo(memoryStream);
+                    bytes = memoryStream.ToArray();
+                }
             }
 
             if (bytes.Length == 0)


### PR DESCRIPTION
When stream.Length <= int.MaxValue, the stream can just be read in one
go into a byte[], instead of going through MemoryStream.ToArray(). This
reduces the number of byte[] allocations when initializing.