### PR TITLE
Make namespace explicit in creating/opening MemoryMappedFile

### DIFF
--- a/MaxMind.Db.Test/ThreadingTest.cs
+++ b/MaxMind.Db.Test/ThreadingTest.cs
@@ -21,6 +21,7 @@ namespace MaxMind.Db.Test
 
         [Theory]
         [InlineData(FileAccessMode.MemoryMapped)]
+        [InlineData(FileAccessMode.MemoryMappedGlobal)]
         [InlineData(FileAccessMode.Memory)]
         public void TestParallelFor(FileAccessMode mode)
         {
@@ -55,6 +56,7 @@ namespace MaxMind.Db.Test
 
         [Theory]
         [InlineData(FileAccessMode.MemoryMapped)]
+        [InlineData(FileAccessMode.MemoryMappedGlobal)]
         [InlineData(FileAccessMode.Memory)]
         [Trait("Category", "BreaksMono")]
         public void TestManyOpens(FileAccessMode mode)

--- a/MaxMind.Db/MemoryMapBuffer.cs
+++ b/MaxMind.Db/MemoryMapBuffer.cs
@@ -16,15 +16,17 @@ namespace MaxMind.Db
         private readonly MemoryMappedViewAccessor _view;
         private bool _disposed;
 
-        internal MemoryMapBuffer(string file) : this(file, new FileInfo(file))
+        internal MemoryMapBuffer(string file, bool useGlobalNamespace) : this(file, useGlobalNamespace, new FileInfo(file))
         {
         }
 
-        private MemoryMapBuffer(string file, FileInfo fileInfo) : base((int)fileInfo.Length)
+        private MemoryMapBuffer(string file, bool useGlobalNamespace, FileInfo fileInfo) : base((int)fileInfo.Length)
         {
             // Ideally we would use the file ID in the mapName, but it is not
             // easily available from C#.
-            var mapName = $"{fileInfo.FullName.Replace("\\", "-")}-{Length}";
+            var objectNamespace = useGlobalNamespace ? "Global" : "Local";
+
+            var mapName = $"{objectNamespace}\\{fileInfo.FullName.Replace("\\", "-")}-{Length}";
             lock (FileLocker)
             {
                 try
@@ -40,8 +42,15 @@ namespace MaxMind.Db
                     var stream = new FileStream(file, FileMode.Open, FileAccess.Read,
                                                 FileShare.Delete | FileShare.Read);
 #if !NETSTANDARD1_4 && !NETSTANDARD2_0
+                    var security = new MemoryMappedFileSecurity();
+                    security.AddAccessRule(
+                        new System.Security.AccessControl.AccessRule<MemoryMappedFileRights>(
+                            new System.Security.Principal.SecurityIdentifier(System.Security.Principal.WellKnownSidType.WorldSid, null),
+                            MemoryMappedFileRights.Read,
+                            System.Security.AccessControl.AccessControlType.Allow));
+
                     _memoryMappedFile = MemoryMappedFile.CreateFromFile(stream, mapName, Length,
-                            MemoryMappedFileAccess.Read, null, HandleInheritability.None, false);
+                            MemoryMappedFileAccess.Read, security, HandleInheritability.None, false);
 #else
 
                     // In .NET Core, named maps are not supported for Unices yet: https://github.com/dotnet/corefx/issues/1329

--- a/MaxMind.Db/Reader.cs
+++ b/MaxMind.Db/Reader.cs
@@ -20,9 +20,17 @@ namespace MaxMind.Db
         MemoryMapped,
 
         /// <summary>
+        ///     Open the file in global memory mapped mode. Requires the 'create global objects' right. Does not load into real memory.
+        /// </summary>
+        /// <remarks>
+        ///     For information on the 'create global objects' right, see: https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/create-global-objects
+        /// </remarks>
+        MemoryMappedGlobal,
+
+        /// <summary>
         ///     Load the file into memory.
         /// </summary>
-        Memory
+        Memory,
     }
 
     /// <summary>
@@ -68,7 +76,10 @@ namespace MaxMind.Db
             switch (mode)
             {
                 case FileAccessMode.MemoryMapped:
-                    return new MemoryMapBuffer(file);
+                    return new MemoryMapBuffer(file, false);
+
+                case FileAccessMode.MemoryMappedGlobal:
+                    return new MemoryMapBuffer(file, true);
 
                 case FileAccessMode.Memory:
                     return new ArrayBuffer(file);


### PR DESCRIPTION
Fixes #33.

Explicitly specifies namespace when creating `MemoryMappedFile`. Adds `MemoryMappedGlobal` to `FileAccessMode` to support use of the global namespace - this requires the ['create global objects' right](https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/create-global-objects), so the default `MemoryMapped` mode uses the local namespace.