### PR TITLE
Add support for setting the network associated with the record

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,33 +11,18 @@ env:
 matrix:
   include:
   - os: linux
-    dist: trusty # Ubuntu 14.04
-    dotnet: 1.0.4
-    mono: none
-    sudo: required
-    env: DOTNETCORE=1 CONSOLE_FRAMEWORK=netcoreapp1.0
-  - os: osx
-    osx_image: xcode7.3 # macOS 10.11
-    dotnet: 1.0.4
-    mono: none
-    env: DOTNETCORE=1 CONSOLE_FRAMEWORK=netcoreapp1.0
-  - os: linux
-    dist: trusty # Ubuntu 14.04
-    dotnet: 2.0.0
+    dotnet: 2.2
     mono: none
     sudo: required
     env: DOTNETCORE=1 CONSOLE_FRAMEWORK=netcoreapp2.0
   - os: osx
-    osx_image: xcode9 # macOS 10.12
-    dotnet: 2.0.0
+    dotnet: 2.2.402
     mono: none
     env: DOTNETCORE=1 CONSOLE_FRAMEWORK=netcoreapp2.0
   - os: linux
-    dist: trusty # Ubuntu 14.04
     mono: latest
     sudo: false
   - os: osx
-    osx_image: xcode7.3 # macOS 10.11
     mono: latest
 
 install: git submodule update --init --recursive

--- a/MaxMind.Db.Benchmark/Program.cs
+++ b/MaxMind.Db.Benchmark/Program.cs
@@ -38,12 +38,12 @@ namespace MaxMind.Db.Benchmark
 
     public class Program
     {
-        private static readonly int COUNT = 500000;
+        private const int Count = 500000;
 
         private static void Main(string[] args)
         {
             // first we check if the command-line argument is provided
-            string dbPath = args.Length > 0 ? args[0] : null;
+            var dbPath = args.Length > 0 ? args[0] : null;
             if (dbPath != null)
             {
                 if (!File.Exists(dbPath))
@@ -86,7 +86,7 @@ namespace MaxMind.Db.Benchmark
         {
             var rand = new Random(1);
             var s = Stopwatch.StartNew();
-            for (var i = 0; i < COUNT; i++)
+            for (var i = 0; i < Count; i++)
             {
                 var ip = new IPAddress(rand.Next(int.MaxValue));
                 op(ip);
@@ -94,7 +94,7 @@ namespace MaxMind.Db.Benchmark
                     Console.WriteLine(i + " " + ip);
             }
             s.Stop();
-            Console.WriteLine("{0}: {1:N0} queries per second", name, COUNT / s.Elapsed.TotalSeconds);
+            Console.WriteLine("{0}: {1:N0} queries per second", name, Count / s.Elapsed.TotalSeconds);
         }
     }
 }

--- a/MaxMind.Db.Benchmark/Program.cs
+++ b/MaxMind.Db.Benchmark/Program.cs
@@ -70,7 +70,7 @@ namespace MaxMind.Db.Benchmark
 
                     if (!File.Exists(dbPath))
                     {
-                        throw new Exception($"{dbPath} does not exist in current directory!");
+                        throw new Exception($"{dbPath} does not exist in current directory ({Directory.GetCurrentDirectory()})!");
                     }
                 }
             }

--- a/MaxMind.Db.Test/DecoderTest.cs
+++ b/MaxMind.Db.Test/DecoderTest.cs
@@ -37,7 +37,7 @@ namespace MaxMind.Db.Test
                 using (var database = new ArrayBuffer(input))
                 {
                     var decoder = new Decoder(database, 0, false);
-                    var val = decoder.Decode<T>(0, out long offset);
+                    var val = decoder.Decode<T>(0, out _);
                     if (useShouldBe)
                     {
                         val.Should().Be(expect);
@@ -215,8 +215,8 @@ namespace MaxMind.Db.Test
                 {(1 << 19) - 5, new byte[] {0x2f, 0xf7, 0xfb}},
                 {(1 << 19) + (1 << 11) - 1, new byte[] {0x2f, 0xff, 0xff}},
                 {(1 << 27) - 2, new byte[] {0x37, 0xf7, 0xf7, 0xfe}},
-                {(((long) 1) << 27) + (1 << 19) + (1 << 11) - 1, new byte[] {0x37, 0xff, 0xff, 0xff}},
-                {(((long) 1) << 31) - 1, new byte[] {0x38, 0x7f, 0xff, 0xff, 0xff}}
+                {((long) 1 << 27) + (1 << 19) + (1 << 11) - 1, new byte[] {0x37, 0xff, 0xff, 0xff}},
+                {((long) 1 << 31) - 1, new byte[] {0x38, 0x7f, 0xff, 0xff, 0xff}}
             };
 
             yield return new object[] { pointers };

--- a/MaxMind.Db.Test/Helper/NoNetworkTypeHolder.cs
+++ b/MaxMind.Db.Test/Helper/NoNetworkTypeHolder.cs
@@ -7,86 +7,71 @@ using System.Numerics;
 
 namespace MaxMind.Db.Test.Helper
 {
-    public class InnerMapX
+    public class NNInnerMapX
     {
         [Constructor]
-        public InnerMapX(
+        public NNInnerMapX(
             string utf8_stringX,
-            [Network] Network network,
             LinkedList<long> arrayX
             )
         {
             ArrayX = arrayX;
-            Network = network;
             Utf8StringX = utf8_stringX;
         }
 
         public LinkedList<long> ArrayX { get; set; }
 
-        public Network Network { get; set; }
-
         public string Utf8StringX { get; set; }
     }
 
-    public class InnerMap
+    public class NNInnerMap
     {
         [Constructor]
-        public InnerMap(InnerMapX mapX)
+        public NNInnerMap(NNInnerMapX mapX)
         {
             MapX = mapX;
         }
 
-        public InnerMapX MapX { get; set; }
+        public NNInnerMapX MapX { get; set; }
     }
 
-    public class InnerNonexistant
+    public class NNInnerNonexistant
     {
         [Constructor]
-        public InnerNonexistant(
-            // To test these are set even if the parent and grandparent
+        public NNInnerNonexistant(
+            // To test this is set even if the parent and grandparent
             // don't exist in the database.
-            [Inject("injected")] string injected,
-            [Network] Network network
+            [Inject("injected")] string injected
             )
         {
             Injected = injected;
-            Network = network;
         }
 
         public string Injected { get; set; }
-        public Network Network { get; }
     }
 
-    public class Nonexistant
+    public class NNNonexistant
     {
         [Constructor]
-        public Nonexistant(
-            [Parameter("innerNonexistant", true)] InnerNonexistant innerNonexistant,
-            // The next two test that they are set even if the parent map doesn't exist
+        public NNNonexistant(
+            [Parameter("innerNonexistant", true)] NNInnerNonexistant innerNonexistant,
+            // To test this is set even if the parent map doesn't exist
             // in the database.
-            [Inject("injected")] string injected,
-            [Network] Network network,
-            // Test that repeated network parameters work, or at least don't blow
-            // up. Not sure why you would want to do this.
-            [Network] Network network2
+            [Inject("injected")] string injected
             )
         {
             Injected = injected;
             InnerNonexistant = innerNonexistant;
-            Network = network;
-            Network2 = network2;
         }
 
         public string Injected { get; set; }
-        public InnerNonexistant InnerNonexistant { get; set; }
-        public Network Network { get; }
-        public Network Network2 { get; }
+        public NNInnerNonexistant InnerNonexistant { get; set; }
     }
 
-    public class TypeHolder
+    public class NoNetworkTypeHolder
     {
         [Constructor]
-        public TypeHolder(
+        public NoNetworkTypeHolder(
             string utf8_string,
             byte[] bytes,
             int uint16,
@@ -98,8 +83,8 @@ namespace MaxMind.Db.Test.Helper
             ICollection<long> array,
             [Parameter("double")] double mmDouble,
             [Parameter("float")] float mmFloat,
-            [Parameter("map")] InnerMap map,
-            [Parameter("nonexistant", true)] Nonexistant nonexistant
+            [Parameter("map")] NNInnerMap map,
+            [Parameter("nonexistant", true)] NNNonexistant nonexistant
             )
         {
             Array = array;
@@ -121,7 +106,7 @@ namespace MaxMind.Db.Test.Helper
             Nonexistant = nonexistant;
         }
 
-        public Nonexistant Nonexistant { get; set; }
+        public NNNonexistant Nonexistant { get; set; }
 
         public ICollection<long> Array { get; set; }
         public bool Boolean { get; set; }
@@ -131,7 +116,7 @@ namespace MaxMind.Db.Test.Helper
         public double Double { get; set; }
         public float Float { get; set; }
 
-        public InnerMap Map { get; set; }
+        public NNInnerMap Map { get; set; }
 
         public long Int32 { get; set; }
         public int Uint16 { get; set; }

--- a/MaxMind.Db.Test/Helper/NonSeekableStreamWrapper.cs
+++ b/MaxMind.Db.Test/Helper/NonSeekableStreamWrapper.cs
@@ -12,7 +12,7 @@ namespace MaxMind.Db.Test.Helper
         {
             _wrappedStream = wrappedStream;
         }
-        
+
         public override void Flush()
         {
             _wrappedStream.Flush();
@@ -44,7 +44,7 @@ namespace MaxMind.Db.Test.Helper
         }
 
         public override bool CanRead => _wrappedStream.CanRead;
-        public override bool CanSeek =>false;
+        public override bool CanSeek => false;
         public override bool CanWrite => _wrappedStream.CanWrite;
         public override long Length => throw new NotSupportedException();
 

--- a/MaxMind.Db.Test/Helper/TestUtils.cs
+++ b/MaxMind.Db.Test/Helper/TestUtils.cs
@@ -11,7 +11,7 @@ namespace MaxMind.Db.Test.Helper
         private static string GetTestDirectory()
         {
             // check if environment variable MAXMIND_TEST_BASE_DIR is set
-            string dbPath = Environment.GetEnvironmentVariable("MAXMIND_TEST_BASE_DIR");
+            var dbPath = Environment.GetEnvironmentVariable("MAXMIND_TEST_BASE_DIR");
 
             if (!string.IsNullOrEmpty(dbPath))
             {

--- a/MaxMind.Db.Test/MaxMind.Db.Test.csproj
+++ b/MaxMind.Db.Test/MaxMind.Db.Test.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IPAddressRange" Version="3.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="FluentAssertions" Version="5.6.0" />
+    <PackageReference Include="IPAddressRange" Version="4.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/MaxMind.Db.Test/NetworkTest.cs
+++ b/MaxMind.Db.Test/NetworkTest.cs
@@ -1,0 +1,34 @@
+﻿using System.Net;
+using Xunit;
+
+namespace MaxMind.Db.Test
+{
+    public class NetworkTest
+    {
+        [Fact]
+        public void TestIPv6()
+        {
+            var network = new Network(
+                IPAddress.Parse("2001:0db8:85a3:0000:0000:8a2e:0370:7334"),
+                28
+                );
+
+            Assert.Equal("2001:db0::", network.NetworkAddress.ToString());
+            Assert.Equal(28, network.PrefixLength);
+            Assert.Equal("2001:db0::/28", network.ToString());
+        }
+
+        [Fact]
+        public void TestIPv4()
+        {
+            var network = new Network(
+                IPAddress.Parse("192.168.213.111"),
+                31
+                );
+
+            Assert.Equal("192.168.213.110", network.NetworkAddress.ToString());
+            Assert.Equal(31, network.PrefixLength);
+            Assert.Equal("192.168.213.110/31", network.ToString());
+        }
+    }
+}

--- a/MaxMind.Db.Test/PointerTest.cs
+++ b/MaxMind.Db.Test/PointerTest.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using FluentAssertions;
 using MaxMind.Db.Test.Helper;
 using Xunit;
@@ -22,22 +21,22 @@ namespace MaxMind.Db.Test
             {
                 var decoder = new Decoder(database, 0);
 
-                var node = decoder.Decode<Dictionary<string, object>>(0, out long offset);
+                var node = decoder.Decode<Dictionary<string, object>>(0, out _);
                 node["long_key"].Should().Be("long_value1");
 
-                node = decoder.Decode<Dictionary<string, object>>(22, out offset);
+                node = decoder.Decode<Dictionary<string, object>>(22, out _);
                 node["long_key"].Should().Be("long_value2");
 
-                node = decoder.Decode<Dictionary<string, object>>(37, out offset);
+                node = decoder.Decode<Dictionary<string, object>>(37, out _);
                 node["long_key2"].Should().Be("long_value1");
 
-                node = decoder.Decode<Dictionary<string, object>>(50, out offset);
+                node = decoder.Decode<Dictionary<string, object>>(50, out _);
                 node["long_key2"].Should().Be("long_value2");
 
-                node = decoder.Decode<Dictionary<string, object>>(55, out offset);
+                node = decoder.Decode<Dictionary<string, object>>(55, out _);
                 node["long_key"].Should().Be("long_value1");
 
-                node = decoder.Decode<Dictionary<string, object>>(57, out offset);
+                node = decoder.Decode<Dictionary<string, object>>(57, out _);
                 node["long_key2"].Should().Be("long_value2");
             }
         }

--- a/MaxMind.Db.Test/ReaderTest.cs
+++ b/MaxMind.Db.Test/ReaderTest.cs
@@ -297,7 +297,7 @@ namespace MaxMind.Db.Test
                     count++;
                 }
 
-            count.Should().Be(269);
+            count.Should().Be(297);
         }
 
         [Fact]
@@ -314,7 +314,7 @@ namespace MaxMind.Db.Test
                     count++;
                 }
 
-            count.Should().Be(22);
+            count.Should().Be(26);
         }
 
         private void TestDecodingTypes(IDictionary<string, object> record)

--- a/MaxMind.Db.Test/ReaderTest.cs
+++ b/MaxMind.Db.Test/ReaderTest.cs
@@ -410,12 +410,13 @@ namespace MaxMind.Db.Test
             injectables.AddValue("injectable", "injectable_value");
             injectables.AddValue("injected", "injected_value");
             using (var reader = new Reader(Path.Combine(_testDataRoot, "MaxMind-DB-test-decoder.mmdb")))
-                foreach (var node in reader.FindAll<TypeHolder>(injectables))
+            {
+                foreach (var node in reader.FindAll<NoNetworkTypeHolder>(injectables))
                 {
                     TestNode(reader, node, injectables);
                     count++;
                 }
-
+            }
             count.Should().Be(26);
         }
 
@@ -463,7 +464,7 @@ namespace MaxMind.Db.Test
             {
                 var injectables = new InjectableValues();
                 injectables.AddValue("injected", "injected string");
-                var record = reader.Find<TypeHolder>(IPAddress.Parse("::1.1.1.0"), injectables);
+                var record = reader.Find<TypeHolder>(IPAddress.Parse("1.1.1.1"), injectables);
 
                 record.Boolean.Should().BeTrue();
                 record.Bytes.Should().Equal(0, 0, 0, 42);
@@ -473,8 +474,8 @@ namespace MaxMind.Db.Test
 
                 var mapX = record.Map.MapX;
                 mapX.Utf8StringX.Should().Be("hello");
-
                 mapX.ArrayX.Should().Equal(new List<long> { 7, 8, 9 });
+                mapX.Network.ToString().Should().Be("1.1.1.0/24");
 
                 record.Double.Should().BeApproximately(42.123456, 0.000000001);
                 record.Float.Should().BeApproximately(1.1F, 0.000001F);
@@ -485,7 +486,11 @@ namespace MaxMind.Db.Test
                 record.Uint128.Should().Be(BigInteger.Parse("1329227995784915872903807060280344576"));
 
                 record.Nonexistant.Injected.Should().Be("injected string");
+                record.Nonexistant.Network.ToString().Should().Be("1.1.1.0/24");
+                record.Nonexistant.Network2.ToString().Should().Be("1.1.1.0/24");
+
                 record.Nonexistant.InnerNonexistant.Injected.Should().Be("injected string");
+                record.Nonexistant.InnerNonexistant.Network.ToString().Should().Be("1.1.1.0/24");
             }
         }
 

--- a/MaxMind.Db.Test/ReaderTest.cs
+++ b/MaxMind.Db.Test/ReaderTest.cs
@@ -7,13 +7,11 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Numerics;
-using System.Reflection;
 using System.Threading.Tasks;
 using FluentAssertions;
 using MaxMind.Db.Test.Helper;
 using Xunit;
 using NetTools;
-using System.Diagnostics;
 
 #endregion
 
@@ -277,7 +275,7 @@ namespace MaxMind.Db.Test
         private void TestNode<T>(Reader reader, Reader.ReaderIteratorNode<T> node, InjectableValues injectables = null) where T : class
         {
             // ensure start ip and prefix length are valid, will throw if not
-            IPAddressRange range = new IPAddressRange(node.Start, node.PrefixLength);
+            var range = new IPAddressRange(node.Start, node.PrefixLength);
 
             // ensure a lookup back into the db produces correct results
             var find = reader.Find<T>(range.Begin, injectables);
@@ -291,29 +289,31 @@ namespace MaxMind.Db.Test
         [Fact]
         public void TestEnumerateCountryDatabase()
         {
-            int count = 0;
+            var count = 0;
             using (var reader = new Reader(Path.Combine(_testDataRoot, "GeoIP2-Country-Test.mmdb")))
-            foreach (var node in reader.FindAll<Dictionary<string, object>>())
-            {
-                TestNode(reader, node);
-                count++;
-            }
+                foreach (var node in reader.FindAll<Dictionary<string, object>>())
+                {
+                    TestNode(reader, node);
+                    count++;
+                }
+
             count.Should().Be(269);
         }
 
         [Fact]
         public void TestEnumerateDecoderDatabase()
         {
-            int count = 0;
-            InjectableValues injectables = new InjectableValues();
+            var count = 0;
+            var injectables = new InjectableValues();
             injectables.AddValue("injectable", "injectable_value");
             injectables.AddValue("injected", "injected_value");
             using (var reader = new Reader(Path.Combine(_testDataRoot, "MaxMind-DB-test-decoder.mmdb")))
-            foreach (var node in reader.FindAll<TypeHolder>(injectables))
-            {
-                TestNode(reader, node, injectables);
-                count++;
-            }
+                foreach (var node in reader.FindAll<TypeHolder>(injectables))
+                {
+                    TestNode(reader, node, injectables);
+                    count++;
+                }
+
             count.Should().Be(22);
         }
 
@@ -321,7 +321,7 @@ namespace MaxMind.Db.Test
         {
             ((bool)record["boolean"]).Should().BeTrue();
 
-            ((byte[])record["bytes"]).Should().Equal(new byte[] { 0, 0, 0, 42 });
+            ((byte[])record["bytes"]).Should().Equal(0, 0, 0, 42);
 
             record["utf8_string"].Should().Be("unicode! ☯ - ♫");
 
@@ -364,7 +364,7 @@ namespace MaxMind.Db.Test
                 var record = reader.Find<TypeHolder>(IPAddress.Parse("::1.1.1.0"), injectables);
 
                 record.Boolean.Should().BeTrue();
-                record.Bytes.Should().Equal(new byte[] { 0, 0, 0, 42 });
+                record.Bytes.Should().Equal(0, 0, 0, 42);
                 record.Utf8String.Should().Be("unicode! ☯ - ♫");
 
                 record.Array.Should().Equal(new List<long> { 1, 2, 3 });
@@ -500,14 +500,14 @@ namespace MaxMind.Db.Test
         {
             foreach (var address in singleAddresses)
             {
-                (reader.Find<Dictionary<string, object>>(IPAddress.Parse(address)))["ip"].Should().Be(
+                reader.Find<Dictionary<string, object>>(IPAddress.Parse(address))["ip"].Should().Be(
                     new string(address.ToArray()),
                     $"Did not find expected data record for {address} in {file}");
             }
 
             foreach (var address in pairs.Keys)
             {
-                (reader.Find<Dictionary<string, object>>(IPAddress.Parse(address)))["ip"].Should().Be(
+                reader.Find<Dictionary<string, object>>(IPAddress.Parse(address))["ip"].Should().Be(
                     pairs[address],
                     $"Did not find expected data record for {address} in {file}");
             }
@@ -520,7 +520,7 @@ namespace MaxMind.Db.Test
 
             foreach (var address in prefixes.Keys)
             {
-                reader.Find<Dictionary<string, object>>(IPAddress.Parse(address), out int routingPrefix);
+                reader.Find<Dictionary<string, object>>(IPAddress.Parse(address), out var routingPrefix);
                 routingPrefix.Should().Be(prefixes[address],
                     $"Invalid prefix for {address} in {file}");
             }

--- a/MaxMind.Db.Test/ThreadingTest.cs
+++ b/MaxMind.Db.Test/ThreadingTest.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Reflection;
 using System.Threading.Tasks;
 using MaxMind.Db.Test.Helper;
 using Xunit;
@@ -25,7 +24,6 @@ namespace MaxMind.Db.Test
         [InlineData(FileAccessMode.Memory)]
         public void TestParallelFor(FileAccessMode mode)
         {
-            var count = 0;
             var ipsAndResults = new Dictionary<IPAddress, string>();
             var rand = new Random();
             using (var reader = new Reader(_testDatabase, mode))
@@ -34,11 +32,8 @@ namespace MaxMind.Db.Test
                 {
                     var ip = new IPAddress(rand.Next(int.MaxValue));
                     var resp = reader.Find<object>(ip);
-                    if (resp != null && !ipsAndResults.ContainsKey(ip))
-                    {
-                        ipsAndResults.Add(ip, resp.ToString());
-                        count++;
-                    }
+                    if (resp == null || ipsAndResults.ContainsKey(ip)) continue;
+                    ipsAndResults.Add(ip, resp.ToString());
                 }
 
                 var ips = ipsAndResults.Keys.ToArray();

--- a/MaxMind.Db/ArrayBuffer.cs
+++ b/MaxMind.Db/ArrayBuffer.cs
@@ -31,7 +31,7 @@ namespace MaxMind.Db
             using (var stream = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, true))
             {
                 return await CreateAsync(stream).ConfigureAwait(false);
-            };
+            }
         }
 
         internal static async Task<ArrayBuffer> CreateAsync(Stream stream)

--- a/MaxMind.Db/MaxMind.Db.csproj
+++ b/MaxMind.Db/MaxMind.Db.csproj
@@ -35,4 +35,19 @@
     <CodeAnalysisDictionary Include="CustomDictionary.xml" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Update="Properties\Settings.Designer.cs">
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Settings.settings</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Properties\Settings.settings">
+      <Generator>SettingsSingleFileGenerator</Generator>
+      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/MaxMind.Db/MemoryMapBuffer.cs
+++ b/MaxMind.Db/MemoryMapBuffer.cs
@@ -62,8 +62,8 @@ namespace MaxMind.Db
                     // In NetStandard1.0 (docs: http://bit.ly/1TOKXEw) and since .Net46 (https://msdn.microsoft.com/en-us/library/dn804422.aspx)
                     // CreateFromFile has a new overload with six arguments (modulo MemoryMappedFileSecurity). While the one with seven arguments
                     // is still available in .Net46, that has been removed from netstandard1.0.
-                     _memoryMappedFile = MemoryMappedFile.CreateFromFile(stream, mapName, Length,
-                             MemoryMappedFileAccess.Read, HandleInheritability.None, false);
+                    _memoryMappedFile = MemoryMappedFile.CreateFromFile(stream, mapName, Length,
+                            MemoryMappedFileAccess.Read, HandleInheritability.None, false);
 #endif
                 }
             }

--- a/MaxMind.Db/Metadata.cs
+++ b/MaxMind.Db/Metadata.cs
@@ -53,12 +53,12 @@ namespace MaxMind.Db
         /// <summary>
         ///     The major version number for the MaxMind DB binary format used by the database.
         /// </summary>
-        public int BinaryFormatMajorVersion { get; private set; }
+        public int BinaryFormatMajorVersion { get; }
 
         /// <summary>
         ///     The minor version number for the MaxMind DB binary format used by the database.
         /// </summary>
-        public int BinaryFormatMinorVersion { get; private set; }
+        public int BinaryFormatMinorVersion { get; }
 
         internal ulong BuildEpoch { get; }
 

--- a/MaxMind.Db/Network.cs
+++ b/MaxMind.Db/Network.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MaxMind.Db
+{
+    /// <summary>
+    ///   <c>Network</c> represents an IP network.
+    /// </summary>
+    public sealed class Network
+    {
+        private IPAddress ip;
+
+        /// <summary>
+        ///     The prefix length is the number of leading 1 bits in the 
+        ///     subnet mask. Sometimes also known as netmask length.
+        /// </summary>
+        public int PrefixLength { get; }
+
+        /// <summary>
+        ///     The first address in the network.
+        /// </summary>
+        public IPAddress NetworkAddress
+        {
+            get
+            {
+                var ipBytes = ip.GetAddressBytes();
+                var networkBytes = new byte[ipBytes.Length];
+                var curPrefix = PrefixLength;
+                for (var i = 0; i < ipBytes.Length && curPrefix > 0; i++)
+                {
+                    var b = ipBytes[i];
+                    if (curPrefix < 8)
+                    {
+                        var shiftN = 8 - curPrefix;
+                        b = (byte)(0xFF & (b >> shiftN) << shiftN);
+                    }
+                    networkBytes[i] = b;
+                    curPrefix -= 8;
+                }
+
+                return new IPAddress(networkBytes);
+            }
+        }
+
+        /// <summary>
+        ///     Constructs a <c>Network</c>.
+        /// </summary>
+        /// <param name="ip">
+        ///     An IP address in the network. This does not have to be the
+        ///     first address in the network.
+        /// </param>
+        /// <param name="prefixLength">The prefix length for the network.</param>
+        public Network(IPAddress ip, int prefixLength)
+        {
+            this.ip = ip;
+            PrefixLength = prefixLength;
+        }
+
+        /// <returns>
+        ///     A string representation of the network in CIDR notation, e.g.,
+        ///     1.2.3.0/24 or 2001::/8.
+        /// </returns>
+        public override string ToString()
+        {
+            return $"{NetworkAddress}/{PrefixLength}";
+        }
+    }
+}

--- a/MaxMind.Db/NetworkAttribute.cs
+++ b/MaxMind.Db/NetworkAttribute.cs
@@ -1,0 +1,22 @@
+﻿#region
+
+using System;
+
+#endregion
+
+namespace MaxMind.Db
+{
+    /// <summary>
+    ///     Instruct <code>Reader</code> to set the parameter to be the network in CIDR format.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter)]
+    public sealed class NetworkAttribute : Attribute
+    {
+        /// <summary>
+        ///     Create a new instance of <code>NetworkAttribute</code>.
+        /// </summary>
+        public NetworkAttribute()
+        {
+        }
+    }
+}

--- a/MaxMind.Db/Properties/AssemblyInfo.cs
+++ b/MaxMind.Db/Properties/AssemblyInfo.cs
@@ -16,7 +16,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("MaxMind, Inc.")]
 [assembly: AssemblyProduct("MaxMind.Db")]
-[assembly: AssemblyCopyright("Copyright © 2013-2016 MaxMind, Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2013-2019 MaxMind, Inc.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/MaxMind.Db/Reader.cs
+++ b/MaxMind.Db/Reader.cs
@@ -404,7 +404,7 @@ namespace MaxMind.Db
                         var offset = baseOffset + index * 3;
                         return _database.ReadOne(offset) << 16 |
                             _database.ReadOne(offset + 1) << 8 |
-                            _database.ReadOne(offset  + 2);
+                            _database.ReadOne(offset + 2);
                     }
                 case 28:
                     {

--- a/MaxMind.Db/Reader.cs
+++ b/MaxMind.Db/Reader.cs
@@ -403,18 +403,32 @@ namespace MaxMind.Db
             {
                 case 24:
                     {
-                        return _database.ReadInteger(0, baseOffset + index * 3, 3);
+                        var offset = baseOffset + index * 3;
+                        return _database.ReadOne(offset) << 16 |
+                            _database.ReadOne(offset + 1) << 8 |
+                            _database.ReadOne(offset  + 2);
                     }
                 case 28:
                     {
-                        var middle = _database.ReadOne(baseOffset + 3);
-                        middle = index == 0 ? (byte)(middle >> 4) : (byte)(0x0F & middle);
-
-                        return _database.ReadInteger(middle, baseOffset + index * 4, 3);
+                        if (index == 0)
+                        {
+                            return ((_database.ReadOne(baseOffset + 3) & 0xF0) << 20) |
+                                    (_database.ReadOne(baseOffset) << 16) |
+                                    (_database.ReadOne(baseOffset + 1) << 8) |
+                                    _database.ReadOne(baseOffset + 2);
+                        }
+                        return ((_database.ReadOne(baseOffset + 3) & 0x0F) << 24) |
+                                (_database.ReadOne(baseOffset + 4) << 16) |
+                                (_database.ReadOne(baseOffset + 5) << 8) |
+                                _database.ReadOne(baseOffset + 6);
                     }
                 case 32:
                     {
-                        return _database.ReadInteger(0, baseOffset + index * 4, 4);
+                        var offset = baseOffset + index * 4;
+                        return _database.ReadOne(offset) << 24 |
+                               _database.ReadOne(offset + 1) << 16 |
+                               _database.ReadOne(offset + 2) << 8 |
+                               _database.ReadOne(offset + 3);
                     }
             }
 

--- a/MaxMind.Db/Reader.cs
+++ b/MaxMind.Db/Reader.cs
@@ -338,17 +338,15 @@ namespace MaxMind.Db
 
             var bitLength = rawAddress.Length * 8;
             var record = StartNode(bitLength);
+            var nodeCount = Metadata.NodeCount;
 
-            for (prefixLength = 0; prefixLength < bitLength; prefixLength++)
+            var i = 0;
+            for (; i < bitLength && record < nodeCount; i++)
             {
-                if (record >= Metadata.NodeCount)
-                {
-                    break;
-                }
-                var b = rawAddress[prefixLength / 8];
-                var bit = 1 & (b >> 7 - (prefixLength % 8));
+                var bit = 1 & (rawAddress[i >> 3] >> (7 - (i % 8)));
                 record = ReadNode(record, bit);
             }
+            prefixLength = i;
             if (record == Metadata.NodeCount)
             {
                 // record is empty

--- a/MaxMind.Db/ReflectionUtil.cs
+++ b/MaxMind.Db/ReflectionUtil.cs
@@ -43,9 +43,9 @@ namespace MaxMind.Db
 
         internal static void CheckType(Type expected, Type from)
         {
-            if (!expected.IsAssignableFrom(@from))
+            if (!expected.IsAssignableFrom(from))
             {
-                throw new DeserializationException($"Could not convert '{@from}' to '{expected}'.");
+                throw new DeserializationException($"Could not convert '{from}' to '{expected}'.");
             }
         }
     }

--- a/MaxMind.Db/TypeAcivatorCreator.cs
+++ b/MaxMind.Db/TypeAcivatorCreator.cs
@@ -38,7 +38,7 @@ namespace MaxMind.Db
 
         internal object[] DefaultParameters() => (object[])_defaultParameters.Clone();
 
-        static private object DefaultValue(Type type)
+        private static object DefaultValue(Type type)
         {
             if (type.GetTypeInfo().IsValueType && Nullable.GetUnderlyingType(type) == null)
             {

--- a/README.md
+++ b/README.md
@@ -90,6 +90,6 @@ The MaxMind DB Reader API uses [Semantic Versioning](http://semver.org/).
 
 ## Copyright and License ##
 
-This software is Copyright (c) 2016 by MaxMind, Inc.
+This software is Copyright (c) 2013-2019 by MaxMind, Inc.
 
 This is free software, licensed under the Apache License, Version 2.0.

--- a/README.md
+++ b/README.md
@@ -66,18 +66,18 @@ threads.
 ## Format ##
 
 The MaxMind DB format is an open format for quickly mapping IP addresses to
-records. See [the specification]
-(https://github.com/maxmind/MaxMind-DB/blob/master/MaxMind-DB-spec.md)
+records. See
+[the specification](https://github.com/maxmind/MaxMind-DB/blob/master/MaxMind-DB-spec.md)
 for more information on the format.
 
 ## Bug Tracker ##
 
-Please report all issues with this code using the [GitHub issue tracker]
-(https://github.com/maxmind/MaxMind-DB-Reader-dotnet/issues).
+Please report all issues with this code using the
+[GitHub issue tracker](https://github.com/maxmind/MaxMind-DB-Reader-dotnet/issues).
 
 If you are having an issue with a MaxMind database or service that is not
-specific to this reader, please [contact MaxMind support]
-(http://www.maxmind.com/en/support).
+specific to this reader, please
+[contact MaxMind support](http://www.maxmind.com/en/support).
 
 ## Contributing ##
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ We recommend reusing the `Reader` object rather than creating a new one for
 each lookup. The creation of this object is relatively expensive as it must
 read in metadata for the file.
 
-## Example ##
+## Example Decoding to a Dictionary ##
 
 ```csharp
 
@@ -54,6 +54,56 @@ using (var reader = new Reader("GeoIP2-City.mmdb"))
     var ip = IPAddress.Parse("24.24.24.24");
     var data = reader.Find<Dictionary<string, object>>(ip);
     ...
+}
+```
+
+## Example Decoding to a Model Class ##
+
+```csharp
+using MaxMind.Db;
+using System.Net;
+
+namespace MyCode
+{
+    public class Asn
+    {
+        [Constructor]
+        public AsnResponse(
+            // The Parameter attribute tells the reader to map the database
+            // key to the specified constructor parameter.
+            [Parameter("autonomous_system_number")] long? autonomousSystemNumber,
+            [Parameter("autonomous_system_organization")] string autonomousSystemOrganization,
+
+            // The Inject attribute allows you to inject arbitrary values
+            // when deserializing.
+            [Inject("ip_address")] IPAddress ipAddress),
+
+            // The Network attribute tells the reader to set the constructor
+            // parameter to be the network associated with the record in the
+            // database.
+            [Network] Network network
+        {
+          ...
+        }
+
+        ...
+    }
+
+
+    public class Program
+    {
+        private static void Main(string[] args)
+        {
+            using (var reader = new Reader("GeoLite2-ASN.mmdb"))
+            {
+                var ip = IPAddress.Parse("24.24.24.24");
+                var injectables = new InjectableValues();
+                injectables.AddValue("ip_address", ip);
+                var data = reader.Find<Asn>(ip, injectables);
+                ...
+            }
+        }
+    }
 }
 ```
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 ---
 version: '1.0.{build}'
 
-os: Visual Studio 2017
+os: Visual Studio 2019
 
 environment:
   global:

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -8,6 +8,10 @@
 * A `CreateAsync` static method was added to asynchronously created a
   `MaxMind.Db.Reader` object from database file. Pull request by David
   Warner. GitHub #44.
+* When deserializing to a class, you may now instruct the reader to set a
+  constructor parameter to be the network associated with the record. To do
+  this, use the `Network` attribute. The parameter must be of type
+  `MaxMind.Db.Network`. GitHub #56.
 * As part of #44, the optimization to reduce allocations when loading from
   a seekable stream was removed. The optimization could cause poor
   performance in some instances and its behavior with regard to the stream


### PR DESCRIPTION
When deserializing the object.

This also enhances the tests around getting the prefix length and includes some general code clean-up/modernization.

After doing many runs of the included benchmark, the before and after differences do not appear to be statistically significant. There were some small performance improvements, but then there is the cost of creating the Network object, passing it around, checking if the constructor param needs to be set, etc.