### PR TITLE
Remove dependency on IPAddressRange

### DIFF
--- a/MaxMind.Db.Test/MaxMind.Db.Test.csproj
+++ b/MaxMind.Db.Test/MaxMind.Db.Test.csproj
@@ -29,7 +29,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IPAddressRange" Version="4.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/MaxMind.Db.Test/ReaderTest.cs
+++ b/MaxMind.Db.Test/ReaderTest.cs
@@ -2,7 +2,6 @@
 
 using FluentAssertions;
 using MaxMind.Db.Test.Helper;
-using NetTools;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -350,11 +349,11 @@ namespace MaxMind.Db.Test
 
         private void TestNode<T>(Reader reader, Reader.ReaderIteratorNode<T> node, InjectableValues? injectables = null) where T : class
         {
-            // ensure start ip and prefix length are valid, will throw if not
-            var range = new IPAddressRange(node.Start, node.PrefixLength);
+            var lengthBits = node.Start.GetAddressBytes().Length * 8;
+            lengthBits.Should().BeGreaterOrEqualTo(node.PrefixLength);
 
             // ensure a lookup back into the db produces correct results
-            var find = reader.Find<T>(range.Begin, injectables);
+            var find = reader.Find<T>(node.Start, injectables);
             find.Should().NotBeNull();
             var find2 = reader.Find<T>(node.Start, injectables);
             find2.Should().NotBeNull();


### PR DESCRIPTION
Any particular API of this library is not used here. The library exists
merely for bits length validation that takes place in
`IPAddressRange`'s ctor.

Replace the validation with an assert and removed the dependency from
test project.