### PR TITLE
Stop using FluentAssertions

### DIFF
--- a/MaxMind.Db.Test/DecoderTest.cs
+++ b/MaxMind.Db.Test/DecoderTest.cs
@@ -16,7 +16,7 @@ namespace MaxMind.Db.Test
         [MemberData(nameof(TestUInt16))]
         [MemberData(nameof(TestUInt32))]
         [MemberData(nameof(TestInt32s))]
-        [MemberData(nameof(TestInt64s))]
+        [MemberData(nameof(TestUInt64s))]
         [MemberData(nameof(TestBigIntegers))]
         [MemberData(nameof(TestDoubles))]
         [MemberData(nameof(TestFloats))]
@@ -26,7 +26,7 @@ namespace MaxMind.Db.Test
         [MemberData(nameof(TestBytes))]
         [MemberData(nameof(TestMaps))]
         [MemberData(nameof(TestArrays))]
-        public static void TestTypeDecoding<T>(Dictionary<T, byte[]> tests, bool useShouldBe = false) where T : class
+        public static void TestTypeDecoding<T>(Dictionary<T, byte[]> tests) where T : class
         {
             foreach (var entry in tests)
             {
@@ -36,14 +36,7 @@ namespace MaxMind.Db.Test
                 using var database = new ArrayBuffer(input);
                 var decoder = new Decoder(database, 0, false);
                 var val = decoder.Decode<T>(0, out _);
-                if (useShouldBe)
-                {
                     Assert.Equal(expect, val);
-                }
-                else
-                {
-                    Assert.Equivalent(expect, val);
-                }
             }
         }
 
@@ -55,7 +48,7 @@ namespace MaxMind.Db.Test
                 {(1 << 8) - 1, [0xa1, 0xff] },
                 {500, [0xa2, 0x1, 0xf4] },
                 {10872, [0xa2, 0x2a, 0x78] },
-                {ushort.MaxValue, [0xa2, 0xff, 0xff] }
+                {(int) ushort.MaxValue, [0xa2, 0xff, 0xff] }
             };
 
             yield return [uint16s];
@@ -65,13 +58,13 @@ namespace MaxMind.Db.Test
         {
             var uint32s = new Dictionary<object, byte[]>
             {
-                {0, [0xc0] },
-                {(1 << 8) - 1, [0xc1, 0xff] },
-                {500, [0xc2, 0x1, 0xf4] },
-                {10872, [0xc2, 0x2a, 0x78] },
-                {(1 << 16) - 1, [0xc2, 0xff, 0xff] },
-                {(1 << 24) - 1, [0xc3, 0xff, 0xff, 0xff] },
-                {uint.MaxValue, [0xc4, 0xff, 0xff, 0xff, 0xff] }
+                {0L, [0xc0] },
+                {(1L << 8) - 1, [0xc1, 0xff] },
+                {500L, [0xc2, 0x1, 0xf4] },
+                {10872L, [0xc2, 0x2a, 0x78] },
+                {(1L << 16) - 1, [0xc2, 0xff, 0xff] },
+                {(1L << 24) - 1, [0xc3, 0xff, 0xff, 0xff] },
+                {(long) uint.MaxValue, [0xc4, 0xff, 0xff, 0xff, 0xff] }
             };
 
             yield return [uint32s];
@@ -98,18 +91,18 @@ namespace MaxMind.Db.Test
             yield return [int32s];
         }
 
-        public static IEnumerable<object[]> TestInt64s()
+        public static IEnumerable<object[]> TestUInt64s()
         {
-            var int64s = new Dictionary<object, byte[]>
+            var uint64s = new Dictionary<object, byte[]>
             {
-                {0L, [0x0, 0x2] },
-                {500L, [0x2, 0x2, 0x1, 0xf4] },
-                {10872, [0x2, 0x2, 0x2a, 0x78] }
+                {0UL, [0x0, 0x2] },
+                {500UL, [0x2, 0x2, 0x1, 0xf4] },
+                {10872UL, [0x2, 0x2, 0x2a, 0x78] }
             };
 
             for (var power = 1; power < 8; power++)
             {
-                var key = Int64Pow(2, 8 * power) - 1;
+                var key = UInt64Pow(2, 8 * power) - 1;
                 var value = new byte[2 + power];
 
                 value[0] = (byte)power;
@@ -119,15 +112,15 @@ namespace MaxMind.Db.Test
                     value[i] = 0xff;
                 }
 
-                int64s.Add(key, value);
+                uint64s.Add(key, value);
             }
 
-            yield return [int64s];
+            yield return [uint64s];
         }
 
-        public static long Int64Pow(long x, int pow)
+        public static ulong UInt64Pow(ulong x, int pow)
         {
-            long ret = 1;
+            ulong ret = 1;
             while (pow != 0)
             {
                 if ((pow & 1) == 1)
@@ -162,7 +155,7 @@ namespace MaxMind.Db.Test
                 bigInts.Add(key, value);
             }
 
-            yield return [bigInts, /*useShouldBe*/ true];
+            yield return [bigInts];
         }
 
         public static IEnumerable<object[]> TestDoubles()
@@ -204,16 +197,16 @@ namespace MaxMind.Db.Test
         {
             var pointers = new Dictionary<object, byte[]>
             {
-                {0, [0x20, 0x0] },
-                {5, [0x20, 0x5] },
-                {10, [0x20, 0xa] },
-                {(1 << 10) - 1, [0x23, 0xff] },
-                {3017, [0x28, 0x3, 0xc9] },
-                {(1 << 19) - 5, [0x2f, 0xf7, 0xfb] },
-                {(1 << 19) + (1 << 11) - 1, [0x2f, 0xff, 0xff] },
-                {(1 << 27) - 2, [0x37, 0xf7, 0xf7, 0xfe] },
-                {((long) 1 << 27) + (1 << 19) + (1 << 11) - 1, [0x37, 0xff, 0xff, 0xff] },
-                {((long) 1 << 31) - 1, [0x38, 0x7f, 0xff, 0xff, 0xff] }
+                {0L, [0x20, 0x0] },
+                {5L, [0x20, 0x5] },
+                {10L, [0x20, 0xa] },
+                {(1L << 10) - 1, [0x23, 0xff] },
+                {3017L, [0x28, 0x3, 0xc9] },
+                {(1L << 19) - 5, [0x2f, 0xf7, 0xfb] },
+                {(1L << 19) + (1 << 11) - 1, [0x2f, 0xff, 0xff] },
+                {(1L << 27) - 2, [0x37, 0xf7, 0xf7, 0xfe] },
+                {(1L << 27) + (1 << 19) + (1 << 11) - 1, [0x37, 0xff, 0xff, 0xff] },
+                {(1L << 31) - 1, [0x38, 0x7f, 0xff, 0xff, 0xff] }
             };
 
             yield return [pointers];

--- a/MaxMind.Db.Test/DecoderTest.cs
+++ b/MaxMind.Db.Test/DecoderTest.cs
@@ -1,6 +1,5 @@
 ﻿#region
 
-using FluentAssertions;
 using System;
 using System.Collections.Generic;
 using System.Numerics;
@@ -39,11 +38,11 @@ namespace MaxMind.Db.Test
                 var val = decoder.Decode<T>(0, out _);
                 if (useShouldBe)
                 {
-                    val.Should().Be(expect);
+                    Assert.Equal(expect, val);
                 }
                 else
                 {
-                    val.Should().BeEquivalentTo(expect, options => options.RespectingRuntimeTypes());
+                    Assert.Equivalent(expect, val);
                 }
             }
         }

--- a/MaxMind.Db.Test/MaxMind.Db.Test.csproj
+++ b/MaxMind.Db.Test/MaxMind.Db.Test.csproj
@@ -35,7 +35,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/MaxMind.Db.Test/PointerTest.cs
+++ b/MaxMind.Db.Test/PointerTest.cs
@@ -1,6 +1,5 @@
 ﻿#region
 
-using FluentAssertions;
 using MaxMind.Db.Test.Helper;
 using System.Collections.Generic;
 using System.IO;
@@ -21,22 +20,22 @@ namespace MaxMind.Db.Test
             var decoder = new Decoder(database, 0);
 
             var node = decoder.Decode<Dictionary<string, object>>(0, out _);
-            node["long_key"].Should().Be("long_value1");
+            Assert.Equal("long_value1", node["long_key"]);
 
             node = decoder.Decode<Dictionary<string, object>>(22, out _);
-            node["long_key"].Should().Be("long_value2");
+            Assert.Equal("long_value2", node["long_key"]);
 
             node = decoder.Decode<Dictionary<string, object>>(37, out _);
-            node["long_key2"].Should().Be("long_value1");
+            Assert.Equal("long_value1", node["long_key2"]);
 
             node = decoder.Decode<Dictionary<string, object>>(50, out _);
-            node["long_key2"].Should().Be("long_value2");
+            Assert.Equal("long_value2", node["long_key2"]);
 
             node = decoder.Decode<Dictionary<string, object>>(55, out _);
-            node["long_key"].Should().Be("long_value1");
+            Assert.Equal("long_value1", node["long_key"]);
 
             node = decoder.Decode<Dictionary<string, object>>(57, out _);
-            node["long_key2"].Should().Be("long_value2");
+            Assert.Equal("long_value2", node["long_key2"]);
         }
     }
 }

--- a/MaxMind.Db.Test/ReaderTest.cs
+++ b/MaxMind.Db.Test/ReaderTest.cs
@@ -351,10 +351,10 @@ namespace MaxMind.Db.Test
             Assert.Equal("unicode! ☯ - ♫", record["utf8_string"]);
 
             var array = (List<object>)record["array"];
-            Assert.Equivalent(3, array.Count);
-            Assert.Equivalent(1, array[0]);
-            Assert.Equivalent(2, array[1]);
-            Assert.Equivalent(3, array[2]);
+            Assert.Equal(3, array.Count);
+            Assert.Equal(1L, array[0]);
+            Assert.Equal(2L, array[1]);
+            Assert.Equal(3L, array[2]);
 
             var map = (Dictionary<string, object>)record["map"];
             Assert.Single(map);
@@ -364,17 +364,17 @@ namespace MaxMind.Db.Test
             Assert.Equal("hello", mapX["utf8_stringX"]);
 
             var arrayX = (List<object>)mapX["arrayX"];
-            Assert.Equivalent(3, arrayX.Count);
-            Assert.Equivalent(7, arrayX[0]);
-            Assert.Equivalent(8, arrayX[1]);
-            Assert.Equivalent(9, arrayX[2]);
+            Assert.Equal(3, arrayX.Count);
+            Assert.Equal(7L, arrayX[0]);
+            Assert.Equal(8L, arrayX[1]);
+            Assert.Equal(9L, arrayX[2]);
 
             Assert.Equal(42.123456, (double)record["double"], 9);
             Assert.Equal(1.1F, (float)record["float"], 5);
             Assert.Equal(-268435456, record["int32"]);
             Assert.Equal(100, record["uint16"]);
-            Assert.Equivalent(268435456, record["uint32"]);
-            Assert.Equivalent(1152921504606846976, record["uint64"]);
+            Assert.Equal(268435456L, record["uint32"]);
+            Assert.Equal(1152921504606846976UL, record["uint64"]);
             Assert.Equal(
                 BigInteger.Parse("1329227995784915872903807060280344576"),
                 record["uint128"]);
@@ -407,7 +407,7 @@ namespace MaxMind.Db.Test
             Assert.Equal(-268435456, record.Int32);
             Assert.Equal(100, record.Uint16);
             Assert.Equal(268435456, record.Uint32);
-            Assert.Equivalent(1152921504606846976, record.Uint64);
+            Assert.Equal(1152921504606846976UL, record.Uint64);
             Assert.Equal(BigInteger.Parse("1329227995784915872903807060280344576"), record.Uint128);
 
             Assert.Equal("injected string", record.Nonexistant.Injected);
@@ -443,8 +443,8 @@ namespace MaxMind.Db.Test
             Assert.Equal(0, (float)record["float"], 5);
             Assert.Equal(0, record["int32"]);
             Assert.Equal(0, record["uint16"]);
-            Assert.Equivalent(0, record["uint32"]);
-            Assert.Equivalent(0, record["uint64"]);
+            Assert.Equal(0L, record["uint32"]);
+            Assert.Equal(0UL, record["uint64"]);
             Assert.Equal(new BigInteger(0), record["uint128"]);
         }
 

--- a/MaxMind.Db.Test/ReaderTest.cs
+++ b/MaxMind.Db.Test/ReaderTest.cs
@@ -1,6 +1,5 @@
 ﻿#region
 
-using FluentAssertions;
 using MaxMind.Db.Test.Helper;
 using System;
 using System.Collections.Concurrent;
@@ -182,20 +181,20 @@ namespace MaxMind.Db.Test
         public void NullStreamThrowsArgumentNullException()
         {
 #pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
-            ((Action)(() => new Reader((Stream)null)))
+            var ex = Assert.Throws<ArgumentNullException>(
+                () => new Reader((Stream)null));
 #pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
-                .Should().Throw<ArgumentNullException>()
-                .WithMessage("The database stream must not be null.*");
+            Assert.Contains("The database stream must not be null", ex.Message);
         }
 
         [Fact]
-        public void NullStreamThrowsArgumentNullExceptionAsync()
+        public async Task NullStreamThrowsArgumentNullExceptionAsync()
         {
 #pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
-            ((Func<Task>)(async () => await Reader.CreateAsync((Stream)null)))
+            var ex = await Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await Reader.CreateAsync((Stream)null));
 #pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
-                .Should().ThrowExactlyAsync<ArgumentNullException>()
-                .WithMessage("The database stream must not be null.*");
+            Assert.Contains("The database stream must not be null", ex.Message);
         }
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 
@@ -203,33 +202,33 @@ namespace MaxMind.Db.Test
         public void TestEmptyStream()
         {
             using var stream = new MemoryStream();
-            ((Action)(() => new Reader(stream)))
-                .Should().Throw<InvalidDatabaseException>()
-                .WithMessage("*zero bytes left in the stream*");
+            var ex = Assert.Throws<InvalidDatabaseException>(
+                () => new Reader(stream));
+            Assert.Contains("zero bytes left in the stream", ex.Message);
         }
 
         [Fact]
-        public void TestEmptyStreamAsync()
+        public async Task TestEmptyStreamAsync()
         {
             using var stream = new MemoryStream();
-            ((Func<Task>)(async () => await Reader.CreateAsync(stream)))
-                .Should().ThrowExactlyAsync<InvalidDatabaseException>()
-                .WithMessage("*zero bytes left in the stream*");
+            var ex = await Assert.ThrowsAsync<InvalidDatabaseException>(
+                async () => await Reader.CreateAsync(stream));
+            Assert.Contains("zero bytes left in the stream", ex.Message);
         }
 
         [Fact]
         public void MetadataPointer()
         {
             using var reader = new Reader(Path.Combine(_testDataRoot, "MaxMind-DB-test-metadata-pointers.mmdb"));
-            reader.Metadata.DatabaseType.Should().Be("Lots of pointers in metadata");
+            Assert.Equal("Lots of pointers in metadata", reader.Metadata.DatabaseType);
         }
 
         [Fact]
         public void NoIPV4SearchTree()
         {
             using var reader = new Reader(Path.Combine(_testDataRoot, "MaxMind-DB-no-ipv4-search-tree.mmdb"));
-            reader.Find<string>(IPAddress.Parse("1.1.1.1")).Should().Be("::0/64");
-            reader.Find<string>(IPAddress.Parse("192.1.1.1")).Should().Be("::0/64");
+            Assert.Equal("::0/64", reader.Find<string>(IPAddress.Parse("1.1.1.1")));
+            Assert.Equal("::0/64", reader.Find<string>(IPAddress.Parse("192.1.1.1")));
         }
 
         [Theory]
@@ -251,16 +250,15 @@ namespace MaxMind.Db.Test
             var ip = IPAddress.Parse(ipStr);
             var record = reader.Find<object>(ip, out var prefixLength);
 
-            prefixLength.Should().Be(expectedPrefixLength,
-                $"{expectedPrefixLength} is the prefix length for {ip} in {dbFile}");
+            Assert.Equal(expectedPrefixLength, prefixLength);
 
             if (expectedOK)
             {
-                record.Should().NotBeNull($"there is a record for {ip} in {dbFile}");
+                Assert.NotNull(record);
             }
             else
             {
-                record.Should().BeNull($"there is no record for {ip} in {dbFile}");
+                Assert.Null(record);
             }
         }
 
@@ -295,15 +293,15 @@ namespace MaxMind.Db.Test
             ) where T : class
         {
             var lengthBits = node.Start.GetAddressBytes().Length * 8;
-            lengthBits.Should().BeGreaterOrEqualTo(node.PrefixLength);
+            Assert.True(lengthBits >= node.PrefixLength);
 
             // ensure a lookup back into the db produces correct results
             var find = reader.Find<T>(node.Start, injectables);
-            find.Should().NotBeNull();
+            Assert.NotNull(find);
             var find2 = reader.Find<T>(node.Start, injectables);
-            find2.Should().NotBeNull();
-            find.Should().BeEquivalentTo(find2);
-            find.Should().BeEquivalentTo(node.Data);
+            Assert.NotNull(find2);
+            Assert.Equivalent(find, find2);
+            Assert.Equivalent(node.Data, find);
         }
 
         [Fact]
@@ -319,7 +317,7 @@ namespace MaxMind.Db.Test
                 }
             }
 
-            count.Should().BeGreaterOrEqualTo(397);
+            Assert.True(count >= 397);
         }
 
         [Fact]
@@ -337,7 +335,7 @@ namespace MaxMind.Db.Test
                     count++;
                 }
             }
-            count.Should().Be(26);
+            Assert.Equal(26, count);
         }
 
         private static void TestDecodingTypes(IDictionary<string, object>? record)
@@ -346,39 +344,40 @@ namespace MaxMind.Db.Test
             {
                 throw new Xunit.Sdk.XunitException("unexpected null record value");
             }
-            ((bool)record["boolean"]).Should().BeTrue();
+            Assert.True((bool)record["boolean"]);
 
-            ((byte[])record["bytes"]).Should().Equal(0, 0, 0, 42);
+            Assert.Equal(new byte[] { 0, 0, 0, 42 }, (byte[])record["bytes"]);
 
-            record["utf8_string"].Should().Be("unicode! ☯ - ♫");
+            Assert.Equal("unicode! ☯ - ♫", record["utf8_string"]);
 
             var array = (List<object>)record["array"];
-            array.Should().HaveCount(3);
-            array[0].Should().BeEquivalentTo(1);
-            array[1].Should().BeEquivalentTo(2);
-            array[2].Should().BeEquivalentTo(3);
+            Assert.Equivalent(3, array.Count);
+            Assert.Equivalent(1, array[0]);
+            Assert.Equivalent(2, array[1]);
+            Assert.Equivalent(3, array[2]);
 
             var map = (Dictionary<string, object>)record["map"];
-            map.Should().HaveCount(1);
+            Assert.Single(map);
 
             var mapX = (Dictionary<string, object>)map["mapX"];
-            mapX.Should().HaveCount(2);
-            mapX["utf8_stringX"].Should().Be("hello");
+            Assert.Equal(2, mapX.Count);
+            Assert.Equal("hello", mapX["utf8_stringX"]);
 
             var arrayX = (List<object>)mapX["arrayX"];
-            arrayX.Should().HaveCount(3);
-            arrayX[0].Should().BeEquivalentTo(7);
-            arrayX[1].Should().BeEquivalentTo(8);
-            arrayX[2].Should().BeEquivalentTo(9);
+            Assert.Equivalent(3, arrayX.Count);
+            Assert.Equivalent(7, arrayX[0]);
+            Assert.Equivalent(8, arrayX[1]);
+            Assert.Equivalent(9, arrayX[2]);
 
-            ((double)record["double"]).Should().BeApproximately(42.123456, 0.000000001);
-            ((float)record["float"]).Should().BeApproximately(1.1F, 0.000001F);
-            record["int32"].Should().BeEquivalentTo(-268435456);
-            record["uint16"].Should().BeEquivalentTo(100);
-            record["uint32"].Should().BeEquivalentTo(268435456);
-            record["uint64"].Should().BeEquivalentTo(1152921504606846976);
-            record["uint128"].Should().Be(
-                BigInteger.Parse("1329227995784915872903807060280344576"));
+            Assert.Equal(42.123456, (double)record["double"], 9);
+            Assert.Equal(1.1F, (float)record["float"], 5);
+            Assert.Equal(-268435456, record["int32"]);
+            Assert.Equal(100, record["uint16"]);
+            Assert.Equivalent(268435456, record["uint32"]);
+            Assert.Equivalent(1152921504606846976, record["uint64"]);
+            Assert.Equal(
+                BigInteger.Parse("1329227995784915872903807060280344576"),
+                record["uint128"]);
         }
 
         [Fact]
@@ -392,31 +391,31 @@ namespace MaxMind.Db.Test
             {
                 throw new Xunit.Sdk.XunitException("unexpected null record value");
             }
-            record.Boolean.Should().BeTrue();
-            record.Bytes.Should().Equal(0, 0, 0, 42);
-            record.Utf8String.Should().Be("unicode! ☯ - ♫");
+            Assert.True(record.Boolean);
+            Assert.Equal(new byte[] { 0, 0, 0, 42 }, record.Bytes);
+            Assert.Equal("unicode! ☯ - ♫", record.Utf8String);
 
-            record.Array.Should().Equal(new List<long> { 1, 2, 3 });
+            Assert.Equal(new List<long> { 1, 2, 3 }, record.Array);
 
             var mapX = record.Map.MapX;
-            mapX.Utf8StringX.Should().Be("hello");
-            mapX.ArrayX.Should().Equal(new List<long> { 7, 8, 9 });
-            mapX.Network.ToString().Should().Be("1.1.1.0/24");
+            Assert.Equal("hello", mapX.Utf8StringX);
+            Assert.Equal(new List<long> { 7, 8, 9 }, mapX.ArrayX);
+            Assert.Equal("1.1.1.0/24", mapX.Network.ToString());
 
-            record.Double.Should().BeApproximately(42.123456, 0.000000001);
-            record.Float.Should().BeApproximately(1.1F, 0.000001F);
-            record.Int32.Should().Be(-268435456);
-            record.Uint16.Should().Be(100);
-            record.Uint32.Should().Be(268435456);
-            record.Uint64.Should().Be(1152921504606846976);
-            record.Uint128.Should().Be(BigInteger.Parse("1329227995784915872903807060280344576"));
+            Assert.Equal(42.123456, record.Double, 9);
+            Assert.Equal(1.1F, record.Float, 5);
+            Assert.Equal(-268435456, record.Int32);
+            Assert.Equal(100, record.Uint16);
+            Assert.Equal(268435456, record.Uint32);
+            Assert.Equivalent(1152921504606846976, record.Uint64);
+            Assert.Equal(BigInteger.Parse("1329227995784915872903807060280344576"), record.Uint128);
 
-            record.Nonexistant.Injected.Should().Be("injected string");
-            record.Nonexistant.Network.ToString().Should().Be("1.1.1.0/24");
-            record.Nonexistant.Network2.ToString().Should().Be("1.1.1.0/24");
+            Assert.Equal("injected string", record.Nonexistant.Injected);
+            Assert.Equal("1.1.1.0/24", record.Nonexistant.Network.ToString());
+            Assert.Equal("1.1.1.0/24", record.Nonexistant.Network2.ToString());
 
-            record.Nonexistant.InnerNonexistant.Injected.Should().Be("injected string");
-            record.Nonexistant.InnerNonexistant.Network.ToString().Should().Be("1.1.1.0/24");
+            Assert.Equal("injected string", record.Nonexistant.InnerNonexistant.Injected);
+            Assert.Equal("1.1.1.0/24", record.Nonexistant.InnerNonexistant.Network.ToString());
         }
 
         [Fact]
@@ -428,52 +427,52 @@ namespace MaxMind.Db.Test
             {
                 throw new Xunit.Sdk.XunitException("unexpected null record value");
             }
-                ((bool)record["boolean"]).Should().BeFalse();
+            Assert.False((bool)record["boolean"]);
 
-            ((byte[])record["bytes"]).Should().BeEmpty();
+            Assert.Empty((byte[])record["bytes"]);
 
-            record["utf8_string"].ToString().Should().BeEmpty();
+            Assert.Empty(record["utf8_string"] as string ?? "null");
 
-            record["array"].Should().BeOfType<List<object>>();
-            ((List<object>)record["array"]).Should().BeEmpty();
+            Assert.IsType<List<object>>(record["array"]);
+            Assert.Empty((List<object>)record["array"]);
 
-            record["map"].Should().BeOfType<Dictionary<string, object>>();
-            ((Dictionary<string, object>)record["map"]).Should().BeEmpty();
+            Assert.IsType<Dictionary<string, object>>(record["map"]);
+            Assert.Empty((Dictionary<string, object>)record["map"]);
 
-            ((double)record["double"]).Should().BeApproximately(0, 0.000000001);
-            ((float)record["float"]).Should().BeApproximately(0, 0.000001F);
-            record["int32"].Should().Be(0);
-            record["uint16"].Should().Be(0);
-            record["uint32"].Should().BeEquivalentTo(0);
-            record["uint64"].Should().BeEquivalentTo(0);
-            record["uint128"].Should().Be(new BigInteger(0));
+            Assert.Equal(0, (double)record["double"], 9);
+            Assert.Equal(0, (float)record["float"], 5);
+            Assert.Equal(0, record["int32"]);
+            Assert.Equal(0, record["uint16"]);
+            Assert.Equivalent(0, record["uint32"]);
+            Assert.Equivalent(0, record["uint64"]);
+            Assert.Equal(new BigInteger(0), record["uint128"]);
         }
 
         [Fact]
         public void TestBrokenDatabase()
         {
             using var reader = new Reader(Path.Combine(_testDataRoot, "GeoIP2-City-Test-Broken-Double-Format.mmdb"));
-            ((Action)(() => reader.Find<object>(IPAddress.Parse("2001:220::"))))
-                .Should().Throw<InvalidDatabaseException>()
-                .WithMessage("*contains bad data*");
+            var ex = Assert.Throws<InvalidDatabaseException>(
+                () => reader.Find<object>(IPAddress.Parse("2001:220::")));
+            Assert.Contains("contains bad data", ex.Message);
         }
 
         [Fact]
         public void TestBrokenSearchTreePointer()
         {
             using var reader = new Reader(Path.Combine(_testDataRoot, "MaxMind-DB-test-broken-pointers-24.mmdb"));
-            ((Action)(() => reader.Find<object>(IPAddress.Parse("1.1.1.32"))))
-                .Should().Throw<InvalidDatabaseException>()
-                .WithMessage("*search tree is corrupt*");
+            var ex = Assert.Throws<InvalidDatabaseException>(
+                () => reader.Find<object>(IPAddress.Parse("1.1.1.32")));
+            Assert.Contains("search tree is corrupt", ex.Message);
         }
 
         [Fact]
         public void TestBrokenDataPointer()
         {
             using var reader = new Reader(Path.Combine(_testDataRoot, "MaxMind-DB-test-broken-pointers-24.mmdb"));
-            ((Action)(() => reader.Find<object>(IPAddress.Parse("1.1.1.16"))))
-                .Should().Throw<InvalidDatabaseException>()
-                .WithMessage("*data section contains bad data*");
+            var ex = Assert.Throws<InvalidDatabaseException>(
+                () => reader.Find<object>(IPAddress.Parse("1.1.1.16")));
+            Assert.Contains("data section contains bad data", ex.Message);
         }
 
         private static void TestIPV6(Reader reader, string file)
@@ -529,30 +528,31 @@ namespace MaxMind.Db.Test
 
             foreach (var address in singleAddresses)
             {
-                reader.Find<Dictionary<string, object>>(IPAddress.Parse(address))["ip"].Should().Be(
+                Assert.Equal(
                     new string([.. address]),
-                    $"Did not find expected data record for {address} in {file}");
+                    reader.Find<Dictionary<string, object>>(IPAddress.Parse(address))["ip"]);
             }
 
             foreach (var address in pairs.Keys)
             {
-                reader.Find<Dictionary<string, object>>(IPAddress.Parse(address))["ip"].Should().Be(
+                Assert.Equal(
                     pairs[address],
-                    $"Did not find expected data record for {address} in {file}");
+                    reader.Find<Dictionary<string, object>>(IPAddress.Parse(address))["ip"]);
             }
 #pragma warning restore CS8602 // Dereference of a possibly null reference.
 
             foreach (var address in nullAddresses)
             {
-                reader.Find<object>(IPAddress.Parse(address)).Should().BeNull(
-                    $"Did not find expected data record for {address} in {file}");
+                Assert.Null(
+                    reader.Find<object>(IPAddress.Parse(address)));
             }
 
             foreach (var address in prefixes.Keys)
             {
                 reader.Find<Dictionary<string, object>>(IPAddress.Parse(address), out var routingPrefix);
-                routingPrefix.Should().Be(prefixes[address],
-                    $"Invalid prefix for {address} in {file}");
+                Assert.Equal(
+                    prefixes[address],
+                    routingPrefix);
             }
 
             foreach (var node in reader.FindAll<Dictionary<string, object>>())
@@ -565,14 +565,15 @@ namespace MaxMind.Db.Test
         {
             var metadata = reader.Metadata;
 
-            metadata.BinaryFormatMajorVersion.Should().Be(2);
-            metadata.BinaryFormatMinorVersion.Should().Be(0);
-            metadata.IPVersion.Should().Be(ipVersion);
-            metadata.DatabaseType.Should().Be("Test");
-            metadata.Languages.Should().HaveElementSucceeding("en", "zh");
-            metadata.Description.Should().Contain("en", "Test Database");
-            metadata.Description.Should().Contain("zh", "Test Database Chinese");
-            metadata.Description.Should().NotContain("gibberish", "Lorem ipsum dolor sit amet");
+            Assert.Equal(2, metadata.BinaryFormatMajorVersion);
+            Assert.Equal(0, metadata.BinaryFormatMinorVersion);
+            Assert.Equal(ipVersion, metadata.IPVersion);
+            Assert.Equal("Test", metadata.DatabaseType);
+            Assert.Contains("en", metadata.Languages);
+            Assert.Contains("zh", metadata.Languages);
+            Assert.Equal("Test Database", metadata.Description["en"]);
+            Assert.Equal("Test Database Chinese", metadata.Description["zh"]);
+            Assert.DoesNotContain("gibberish", metadata.Description.Keys);
         }
     }
 }


### PR DESCRIPTION
This reduces the number of dependencies and makes these tests more
similar to our other C# tests.
