### PR TITLE
Optimize DecodeMapToType

### DIFF
--- a/MaxMind.Db/Decoder.cs
+++ b/MaxMind.Db/Decoder.cs
@@ -1,7 +1,7 @@
 ﻿#region
 
 using System;
-#if NETSTANDARD2_1_OR_GREATER || NET8_0_OR_GREATER
+#if !NETSTANDARD2_0
 using System.Buffers;
 #endif
 using System.Collections;
@@ -351,7 +351,7 @@ namespace MaxMind.Db
         {
             var constructor = _typeAcivatorCreator.GetActivator(expectedType);
 
-#if NETSTANDARD2_1_OR_GREATER || NET8_0_OR_GREATER
+#if !NETSTANDARD2_0
             // N.B. Rent can return a larger arrays. This is fine because constructors allow arrays larger than the
             // number of parameters.
             object?[] parameters = ArrayPool<object?>.Shared.Rent(constructor.DefaultParameters.Length);
@@ -383,7 +383,7 @@ namespace MaxMind.Db
             outOffset = offset;
             object obj = constructor.Activator(parameters);
 
-#if NETSTANDARD2_1_OR_GREATER || NET8_0_OR_GREATER
+#if !NETSTANDARD2_0
             ArrayPool<object?>.Shared.Return(parameters);
 #endif
 
@@ -403,7 +403,7 @@ namespace MaxMind.Db
 
                 var activator = _typeAcivatorCreator.GetActivator(param.ParameterType);
 
-#if NETSTANDARD2_1_OR_GREATER || NET8_0_OR_GREATER
+#if !NETSTANDARD2_0
                 object?[] cstorParams = ArrayPool<object?>.Shared.Rent(activator.DefaultParameters.Length);
 #else
                 object?[] cstorParams = new object?[activator.DefaultParameters.Length];
@@ -415,7 +415,7 @@ namespace MaxMind.Db
                 SetAlwaysCreatedParams(activator, cstorParams, injectables, network);
                 parameters[param.Position] = activator.Activator(cstorParams);
 
-#if NETSTANDARD2_1_OR_GREATER || NET8_0_OR_GREATER
+#if !NETSTANDARD2_0
                 ArrayPool<object?>.Shared.Return(cstorParams);
 #endif
             }

--- a/MaxMind.Db/Key.cs
+++ b/MaxMind.Db/Key.cs
@@ -1,6 +1,8 @@
-﻿namespace MaxMind.Db
+﻿using System;
+
+namespace MaxMind.Db
 {
-    internal readonly struct Key
+    internal readonly struct Key : IEquatable<Key>
     {
         private readonly Buffer buffer;
         private readonly long offset;
@@ -21,15 +23,8 @@
             hashCode = code;
         }
 
-        public override bool Equals(object? obj)
+        public bool Equals(Key other)
         {
-            if ((obj == null) || !GetType().Equals(obj.GetType()))
-            {
-                return false;
-            }
-
-            var other = (Key)obj;
-
             if (size != other.size)
             {
                 return false;
@@ -42,7 +37,18 @@
                     return false;
                 }
             }
+
             return true;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (obj == null || typeof(Key) != obj.GetType())
+            {
+                return false;
+            }
+
+            return Equals((Key)obj);
         }
 
         public override int GetHashCode()

--- a/MaxMind.Db/ReflectionUtil.cs
+++ b/MaxMind.Db/ReflectionUtil.cs
@@ -8,7 +8,7 @@ using System.Reflection;
 
 namespace MaxMind.Db
 {
-    internal delegate object ObjectActivator(params object[] args);
+    internal delegate object ObjectActivator(params object?[] args);
 
     internal static class ReflectionUtil
     {


### PR DESCRIPTION
- Implement `IEquatable<T>` on `Key` to avoid boxing the value when using it in a dictionary. This should save one allocation per decoded field.
- Use an array pool for constructor parameters. For .NET Standard 2.0, we could reference the nuget System.Buffers instead of adding preprocessor directives but I prefer to keep the dependencies light. This should save one allocation per decoded type.
- Use arrays instead of Dictionary/List as their enumerator is faster and they benefits more from JIT optimizations
- Make a TypeActivator a class. It's too large to be a struct.

Using the benchmark code from https://github.com/maxmind/MaxMind-DB-Reader-dotnet/pull/210, it's only 1% faster but it allocates ~20% less which will put less pressure on the GC.

214.0.0.0 with GeoIP2-City-Test.mmdb

| Method | Mean     | Error    | StdDev   | Gen0   | Allocated |
|------- |---------:|---------:|---------:|-------:|----------:|
| Before | 10.13 us | 0.114 us | 0.131 us | 0.3967 |   6.66 KB |
| After | 10.04 us | 0.053 us | 0.044 us | 0.3357 |   5.52 KB |


23.56.162.100 with GeoIP2-City.mmdb

| Method | Mean     | Error     | StdDev    | Gen0   | Allocated |
|------- |---------:|----------:|----------:|-------:|----------:|
| Before   | 9.897 us | 0.0198 us | 0.0165 us | 0.3662 |   6.08 KB |
| After   | 9.753 us | 0.1728 us | 0.2185 us | 0.2899 |   4.93 KB |

I've also studied the feasibility to avoid boxing fields in the object[] parameters. It is extremely complex to do that with immutable types. The [commit](https://github.com/dotnet/runtime/commit/4a804959512a76556add344d998f3fc9ca9513e8) that implements this in System.Text.Json is 7K LOC long.