### PR TITLE
Don't fail CI builds on NuGet audit advisories

### DIFF
--- a/MaxMind.Db.Benchmark/MaxMind.Db.Benchmark.csproj
+++ b/MaxMind.Db.Benchmark/MaxMind.Db.Benchmark.csproj
@@ -24,6 +24,10 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- In CI, don't fail the build on NuGet audit advisories (NU1901-NU1905).
+         Advisories still appear in build output, and Dependabot handles the
+         actual fix. Local builds keep the strict behavior. -->
+    <WarningsNotAsErrors Condition="'$(CI)' == 'true'">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904;NU1905</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MaxMind.Db.Test/MaxMind.Db.Test.csproj
+++ b/MaxMind.Db.Test/MaxMind.Db.Test.csproj
@@ -28,6 +28,10 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- In CI, don't fail the build on NuGet audit advisories (NU1901-NU1905).
+         Advisories still appear in build output, and Dependabot handles the
+         actual fix. Local builds keep the strict behavior. -->
+    <WarningsNotAsErrors Condition="'$(CI)' == 'true'">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904;NU1905</WarningsNotAsErrors>
     <EnableMSTestRunner>true</EnableMSTestRunner>
   </PropertyGroup>
 

--- a/MaxMind.Db/MaxMind.Db.csproj
+++ b/MaxMind.Db/MaxMind.Db.csproj
@@ -33,6 +33,10 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- In CI, don't fail the build on NuGet audit advisories (NU1901-NU1905).
+         Advisories still appear in build output, and Dependabot handles the
+         actual fix. Local builds keep the strict behavior. -->
+    <WarningsNotAsErrors Condition="'$(CI)' == 'true'">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904;NU1905</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Add a CI-only `WarningsNotAsErrors` entry for `NU1901`-`NU1904` in the unit-test csproj, so NuGet audit advisories on dependencies don't red-X every build while we wait for a Dependabot upgrade.
- `TreatWarningsAsErrors` stays on, and local builds remain strict — the condition is keyed on the `CI=true` env var that GitHub Actions sets automatically. Advisories still appear in CI build output.

Companion change in GeoIP2-dotnet and minfraud-api-dotnet.

## Test plan
- [ ] CI passes on this branch
- [ ] Introduce a known-vulnerable package locally (without `CI=true`) to confirm the build still fails locally