### PR TITLE
Use unnamed file-backed mmap for MemoryMapped; deprecate Global

### DIFF
--- a/MaxMind.Db.Test/LargeOffsetPointerTest.cs
+++ b/MaxMind.Db.Test/LargeOffsetPointerTest.cs
@@ -45,7 +45,7 @@ namespace MaxMind.Db.Test
             var tempFile = CreateSparseTestFile(raw, baseOffset);
             try
             {
-                using var buffer = new MemoryMapBuffer(tempFile, false);
+                using var buffer = MemoryMapBuffer.CreateFileBacked(tempFile);
                 var decoder = new Decoder(buffer, pointerBase);
 
                 // Before the fix, this threw OverflowException because the
@@ -101,7 +101,7 @@ namespace MaxMind.Db.Test
             var tempFile = CreateSparseTestFile(raw, baseOffset);
             try
             {
-                using var buffer = new MemoryMapBuffer(tempFile, false);
+                using var buffer = MemoryMapBuffer.CreateFileBacked(tempFile);
                 var decoder = new Decoder(buffer, pointerBase);
 
                 // Before the fix, ReadVarInt returned a negative int for

--- a/MaxMind.Db.Test/ReaderTest.cs
+++ b/MaxMind.Db.Test/ReaderTest.cs
@@ -215,6 +215,27 @@ namespace MaxMind.Db.Test
             Assert.Contains("The database is empty.", ex.Message);
         }
 
+        [Theory]
+        [InlineData(FileAccessMode.MemoryMapped)]
+#pragma warning disable CS0618 // Verify deprecated value still functions
+        [InlineData(FileAccessMode.MemoryMappedGlobal)]
+#pragma warning restore CS0618
+        [InlineData(FileAccessMode.Memory)]
+        public void TestEmptyFile(FileAccessMode mode)
+        {
+            var tempFile = Path.GetTempFileName();
+            try
+            {
+                var ex = Assert.Throws<InvalidDatabaseException>(
+                    () => new Reader(tempFile, mode));
+                Assert.Contains("The database is empty.", ex.Message);
+            }
+            finally
+            {
+                File.Delete(tempFile);
+            }
+        }
+
         [Fact]
         public void MetadataPointer()
         {

--- a/MaxMind.Db.Test/ThreadingTest.cs
+++ b/MaxMind.Db.Test/ThreadingTest.cs
@@ -20,7 +20,9 @@ namespace MaxMind.Db.Test
 
         [Theory]
         [InlineData(FileAccessMode.MemoryMapped)]
+#pragma warning disable CS0618 // Verify deprecated value still functions
         [InlineData(FileAccessMode.MemoryMappedGlobal)]
+#pragma warning restore CS0618
         [InlineData(FileAccessMode.Memory)]
         public void TestParallelFor(FileAccessMode mode)
         {
@@ -53,7 +55,9 @@ namespace MaxMind.Db.Test
 
         [Theory]
         [InlineData(FileAccessMode.MemoryMapped)]
+#pragma warning disable CS0618 // Verify deprecated value still functions
         [InlineData(FileAccessMode.MemoryMappedGlobal)]
+#pragma warning restore CS0618
         [InlineData(FileAccessMode.Memory)]
         [Trait("Category", "BreaksMono")]
         public void TestManyOpens(FileAccessMode mode)

--- a/MaxMind.Db/GlobalSuppressions.cs
+++ b/MaxMind.Db/GlobalSuppressions.cs
@@ -9,7 +9,6 @@ using System.Diagnostics.CodeAnalysis;
 
 [assembly: SuppressMessage("Design", "CA1034:Nested types should not be visible", Justification = "ReaderIteratorNode<T> is part of the public FindAll API contract", Scope = "type", Target = "~T:MaxMind.Db.Reader.ReaderIteratorNode`1")]
 [assembly: SuppressMessage("Performance", "CA1815:Override equals and operator equals on value types", Justification = "Struct is used for iteration results, not equality comparison", Scope = "type", Target = "~T:MaxMind.Db.Reader.ReaderIteratorNode`1")]
-[assembly: SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "Platform-specific code paths handled via exception catch in constructor", Scope = "member", Target = "~M:MaxMind.Db.MemoryMapBuffer.#ctor(System.String,System.Boolean,System.IO.FileInfo)")]
 [assembly: SuppressMessage("Style", "IDE0056:Use index operator", Justification = "Index operator requires System.Index, unavailable on netstandard2.0", Scope = "member", Target = "~M:MaxMind.Db.MemoryMapBuffer.ReadBigInteger(System.Int64,System.Int32)~System.Numerics.BigInteger")]
 [assembly: SuppressMessage("Style", "IDE0056:Use index operator", Justification = "Index operator requires System.Index, unavailable on netstandard2.0", Scope = "member", Target = "~M:MaxMind.Db.Reader.FindAll``1(MaxMind.Db.InjectableValues,System.Int32)~System.Collections.Generic.IEnumerable{MaxMind.Db.Reader.ReaderIteratorNode{``0}}")]
 

--- a/MaxMind.Db/MaxMind.Db.csproj
+++ b/MaxMind.Db/MaxMind.Db.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>.NET reader for the MaxMind DB file format</Description>
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <VersionPrefix>5.1.0</VersionPrefix>
     <TargetFrameworks>net10.0;net9.0;net8.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>MaxMind.Db</AssemblyName>

--- a/MaxMind.Db/MemoryMapBuffer.cs
+++ b/MaxMind.Db/MemoryMapBuffer.cs
@@ -5,9 +5,7 @@ using System.IO;
 using System.IO.MemoryMappedFiles;
 using System.Numerics;
 using System.Runtime.CompilerServices;
-using System.Security.Cryptography;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 
 #endregion
@@ -24,68 +22,41 @@ namespace MaxMind.Db
         private bool _disposed;
         internal long Length { get; }
 
-        // Creates a named memory-mapped file backed directly by the file on
-        // disk, suitable for cross-process sharing.
-        internal MemoryMapBuffer(string file, bool useGlobalNamespace) : this(file, useGlobalNamespace, new FileInfo(file))
-        {
-        }
-
-        private MemoryMapBuffer(string file, bool useGlobalNamespace, FileInfo fileInfo)
+        // Creates an unnamed file-backed memory-mapped region. Cross-process
+        // page sharing happens via the OS file cache rather than via a named
+        // section object, so this mode is not subject to the access-denied
+        // failures that can occur when opening an ACL-checked named section
+        // under a different user identity on Windows.
+        internal static MemoryMapBuffer CreateFileBacked(string file)
         {
             using var stream = new FileStream(file, FileMode.Open, FileAccess.Read,
                                               FileShare.Delete | FileShare.Read);
-            Length = stream.Length;
-            // Ideally we would use the file ID in the mapName, but it is not
-            // easily available from C#.
-            var objectNamespace = useGlobalNamespace ? "Global" : "Local";
-
-            // We create a sha256 here as there are limitations on mutex names.
-            using var sha256 = SHA256.Create();
-            var suffixTxt = $"{fileInfo.FullName.Replace("\\", "-")}-{Length}";
-            var hashBytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(suffixTxt));
-            var suffix = BitConverter.ToString(hashBytes).Replace("-", "");
-
-            var mapName = $"{objectNamespace}\\{suffix}";
-            var mutexName = $"{mapName}-Mutex";
-
-            using (var mutex = new Mutex(false, mutexName))
+            var length = stream.Length;
+            if (length == 0)
             {
-                var hasHandle = false;
-
-                try
-                {
-                    hasHandle = mutex.WaitOne(TimeSpan.FromSeconds(10), false);
-                    if (!hasHandle)
-                    {
-                        throw new TimeoutException("Timeout waiting for mutex.");
-                    }
-
-                    _memoryMappedFile = MemoryMappedFile.OpenExisting(mapName, MemoryMappedFileRights.Read);
-                }
-                catch (Exception ex) when (ex is IOException or NotImplementedException or PlatformNotSupportedException)
-                {
-                    // In .NET Core, named maps are not supported for Unices yet: https://github.com/dotnet/corefx/issues/1329
-                    // When executed on unsupported platform, we get the PNSE. In which case, we construct the memory map by
-                    // setting mapName to null.
-                    if (ex is PlatformNotSupportedException)
-                        mapName = null;
-
-                    _memoryMappedFile = MemoryMappedFile.CreateFromFile(stream, mapName, Length,
-                            MemoryMappedFileAccess.Read, HandleInheritability.None, false);
-                }
-                finally
-                {
-                    if (hasHandle)
-                    {
-                        mutex.ReleaseMutex();
-                    }
-                }
+                throw new InvalidDatabaseException("The database is empty.");
             }
-
-            _view = _memoryMappedFile.CreateViewAccessor(0, Length, MemoryMappedFileAccess.Read);
-#if !NETSTANDARD2_0
-            AcquireRawPointer();
-#endif
+            // leaveOpen: true — the `using var stream` above already disposes
+            // the stream on all paths. The OS keeps the underlying file open
+            // via the mapping's internal reference, so the mmf does not need
+            // to own the stream.
+            var mmf = MemoryMappedFile.CreateFromFile(
+                stream,
+                mapName: null,
+                capacity: length,
+                MemoryMappedFileAccess.Read,
+                HandleInheritability.None,
+                leaveOpen: true);
+            try
+            {
+                var view = mmf.CreateViewAccessor(0, length, MemoryMappedFileAccess.Read);
+                return new MemoryMapBuffer(mmf, view, length);
+            }
+            catch
+            {
+                mmf.Dispose();
+                throw;
+            }
         }
 
         // Reads the file into an anonymous memory-mapped region that is

--- a/MaxMind.Db/Reader.cs
+++ b/MaxMind.Db/Reader.cs
@@ -17,16 +17,18 @@ namespace MaxMind.Db
     public enum FileAccessMode
     {
         /// <summary>
-        ///     Open the file in memory mapped mode. Does not load into real memory.
+        ///     Open the file as an unnamed file-backed memory-mapped region.
+        ///     Cross-process page sharing is provided by the OS file cache and
+        ///     does not require special privileges or named-section access
+        ///     rights. Does not load into real memory.
         /// </summary>
         MemoryMapped,
 
         /// <summary>
-        ///     Open the file in global memory mapped mode. Requires the 'create global objects' right. Does not load into real memory.
+        ///     Deprecated. Use <see cref="MemoryMapped"/> instead. This value
+        ///     now behaves identically to <see cref="MemoryMapped"/>.
         /// </summary>
-        /// <remarks>
-        ///     For information on the 'create global objects' right, see: https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/create-global-objects
-        /// </remarks>
+        [Obsolete("MemoryMappedGlobal no longer creates a Global\\ named section or requires the 'create global objects' right; cross-process sharing now relies on the OS file cache. This value will be removed in a future major release. Use FileAccessMode.MemoryMapped.")]
         MemoryMappedGlobal,
 
         /// <summary>
@@ -184,8 +186,10 @@ namespace MaxMind.Db
         {
             return mode switch
             {
-                FileAccessMode.MemoryMapped => new MemoryMapBuffer(file, false),
-                FileAccessMode.MemoryMappedGlobal => new MemoryMapBuffer(file, true),
+                FileAccessMode.MemoryMapped => MemoryMapBuffer.CreateFileBacked(file),
+#pragma warning disable CS0618 // MemoryMappedGlobal is obsolete; routing to MemoryMapped path
+                FileAccessMode.MemoryMappedGlobal => MemoryMapBuffer.CreateFileBacked(file),
+#pragma warning restore CS0618
                 FileAccessMode.Memory => new MemoryMapBuffer(file),
                 _ => throw new ArgumentException("Unknown file access mode"),
             };

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -1,5 +1,20 @@
 # Release Notes
 
+## 5.1.0 (YYYY-MM-DD)
+
+- `FileAccessMode.MemoryMapped` now creates an unnamed file-backed memory-mapped
+  region instead of a named `Local\<sha>` section. Cross-process page sharing
+  continues to work via the OS file cache. This fixes
+  `UnauthorizedAccessException` when multiple processes running under different
+  identities open the same database. Reported by Ross Gehlig. GitHub #290.
+- `FileAccessMode.MemoryMappedGlobal` is deprecated and will be removed in a
+  future major release. Existing usages now route to the same unnamed
+  file-backed path used by `FileAccessMode.MemoryMapped`, so the 'create global
+  objects' right is no longer required.
+- An empty database file now throws `InvalidDatabaseException` consistently
+  across all `FileAccessMode` values, matching the behavior of the
+  `Reader(Stream)` constructor.
+
 ## 5.0.0 (2026-03-12)
 
 - **BREAKING:** Added property-based activation for MMDB deserialization. Types


### PR DESCRIPTION
## Summary

- Switch `FileAccessMode.MemoryMapped` to create an unnamed file-backed memory-mapped region rather than a named `Local\<sha>` section. Cross-process page sharing continues via the OS file cache; the named-section DACL that produced `UnauthorizedAccessException` for cross-identity opens is gone.
- Deprecate `FileAccessMode.MemoryMappedGlobal` with `[Obsolete]` and route it to the same code path. The `'create global objects'` right is no longer required; the value will be removed in 6.0.
- Strip the SHA-256 naming, named mutex, and `OpenExisting`/`CreateFromFile` catch-ladder that supported the old named-mapping flow. Net 39-line reduction in `MemoryMapBuffer.cs`.
- Bump `VersionPrefix` to 5.1.0; `AssemblyVersion` stays at 5.0.0 per the convention established in `ff1646c` (AssemblyVersion tracks the major).

Fixes #290.

The change is Windows-observable only — on Linux/macOS the named path was already dead code (it fell through the `PlatformNotSupportedException` catch and produced an unnamed mapping). On Windows, the `Local\<sha>` section no longer appears in Process Explorer; page sharing is unchanged because the Windows Cache Manager unifies file-backed pages at the `FILE_OBJECT.SectionObjectPointer` level regardless of section naming.

## Test plan

- [x] `dotnet build MaxMind.Db.sln` clean across net10/9/8/netstandard2.1/2.0 under `TreatWarningsAsErrors`, zero warnings
- [x] `dotnet test` passes 207/207 across net10/9/8
- [x] `ThreadingTest.TestParallelFor` and `TestManyOpens` exercise all three `FileAccessMode` values including the deprecated `MemoryMappedGlobal` (pragma-wrapped to suppress CS0618 in the test)
- [x] `LargeOffsetPointerTest` migrated from the deleted 2-arg ctor to `MemoryMapBuffer.CreateFileBacked` (it needs a file-backed mapping for the 2 GiB+ sparse test file)
- [ ] Confirm on Windows that the `Local\<sha>` section is no longer created (visible in Process Explorer) and that multiple processes still share pages via the OS file cache
- [ ] Confirm a downstream consumer sees CS0618 when referencing `FileAccessMode.MemoryMappedGlobal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)