### PR TITLE
Use 'GeoIP'/'GeoLite' branding in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ install-package MaxMind.Db
 
 ## Usage
 
-_Note:_ For accessing MaxMind GeoIP2 databases, we generally recommend using the
-GeoIP2 .NET API rather than using this package directly.
+_Note:_ For accessing MaxMind GeoIP databases, we generally recommend using the
+GeoIP .NET API rather than using this package directly.
 
 To use the API, you must first create a `Reader` object. The constructor for the
 reader object takes a `string` with the path to the MaxMind DB file. Optionally


### PR DESCRIPTION
Updates prose/documentation to refer to the products as "GeoIP"/"GeoLite" instead of "GeoIP2"/"GeoLite2". Technical identifiers (packages, class names, .mmdb filenames, edition IDs, the geolite.info hostname, URLs) and test fixtures are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)