### PR TITLE
Run Dependabot updates weekly and group CodeQL updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,8 @@ updates:
     directories:
       - "**/*"
     schedule:
-      interval: daily
+      interval: weekly
+      day: monday
       time: "14:00"
     open-pull-requests-limit: 10
     cooldown:
@@ -12,7 +13,8 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+      day: monday
       time: "14:00"
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,5 +16,9 @@ updates:
       interval: weekly
       day: monday
       time: "14:00"
+    groups:
+      codeql:
+        patterns:
+          - github/codeql-action*
     cooldown:
       default-days: 7


### PR DESCRIPTION
We now review dependency updates weekly rather than daily, so switch every Dependabot update schedule to weekly on Monday mornings.

Also group the github/codeql-action subpath actions (init, analyze, autobuild): Dependabot treats them as separate dependencies and opens a separate PR for each, but CI fails unless they are all updated together. Grouping them makes the updates arrive as a single PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)