### PR TITLE
Preserve metadata constructor for Native AOT

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,6 +22,7 @@ jobs:
           # We must fetch at least the immediate parents so that if this is
           # a pull request then we can checkout the head.
           fetch-depth: 2
+          submodules: true
           persist-credentials: false
 
       # If this run was triggered by a pull request event, then checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,3 +44,33 @@ jobs:
         run: dotnet test
         env:
           MAXMIND_TEST_BASE_DIR: ${{ github.workspace }}/MaxMind.Db.Test
+
+  native-aot:
+    runs-on: ubuntu-latest
+    name: Native AOT smoke test
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          submodules: true
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Install Native AOT prerequisites
+        run: sudo apt-get update && sudo apt-get install --yes clang zlib1g-dev
+
+      - name: Publish Native AOT smoke test
+        run: >-
+          dotnet publish
+          MaxMind.Db.NativeAot.Test/MaxMind.Db.NativeAot.Test.csproj
+          --configuration Release
+          --framework net10.0
+          --runtime linux-x64
+          --self-contained true
+          --output ${{ runner.temp }}/native-aot
+
+      - name: Run Native AOT smoke test
+        run: ${{ runner.temp }}/native-aot/MaxMind.Db.NativeAot.Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,11 +66,8 @@ jobs:
         run: >-
           dotnet publish
           MaxMind.Db.NativeAot.Test/MaxMind.Db.NativeAot.Test.csproj
-          --configuration Release
-          --framework net10.0
-          --runtime linux-x64
-          --self-contained true
-          --output ${{ runner.temp }}/native-aot
+          --configuration Release --framework net10.0 --runtime linux-x64
+          --self-contained true --output ${{ runner.temp }}/native-aot
 
       - name: Run Native AOT smoke test
         run: ${{ runner.temp }}/native-aot/MaxMind.Db.NativeAot.Test

--- a/MaxMind.Db.NativeAot.Test/MaxMind.Db.NativeAot.Test.csproj
+++ b/MaxMind.Db.NativeAot.Test/MaxMind.Db.NativeAot.Test.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MaxMind.Db\MaxMind.Db.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None
+      Include="..\MaxMind.Db.Test\TestData\MaxMind-DB\test-data\MaxMind-DB-test-decoder.mmdb"
+      Link="MaxMind-DB-test-decoder.mmdb"
+      CopyToOutputDirectory="PreserveNewest"
+      CopyToPublishDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/MaxMind.Db.NativeAot.Test/MaxMind.Db.NativeAot.Test.csproj
+++ b/MaxMind.Db.NativeAot.Test/MaxMind.Db.NativeAot.Test.csproj
@@ -4,7 +4,15 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- Keep the known reflection-path warnings visible until the descriptor
+         design in issue #321 is implemented, while failing on new warnings. -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);IL2067;IL2070;IL3050</WarningsNotAsErrors>
     <PublishAot>true</PublishAot>
     <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>

--- a/MaxMind.Db.NativeAot.Test/Program.cs
+++ b/MaxMind.Db.NativeAot.Test/Program.cs
@@ -1,0 +1,13 @@
+using MaxMind.Db;
+using System.Net;
+
+var databasePath = Path.Combine(AppContext.BaseDirectory, "MaxMind-DB-test-decoder.mmdb");
+using var reader = new Reader(databasePath);
+var record = reader.Find<Dictionary<string, object>>(IPAddress.Parse("::1.1.1.0"));
+
+if (record is null || !Equals(record["utf8_string"], "unicode! ☯ - ♫"))
+{
+    throw new InvalidOperationException("Native AOT lookup returned an unexpected record.");
+}
+
+Console.WriteLine("Native AOT lookup passed.");

--- a/MaxMind.Db.sln
+++ b/MaxMind.Db.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MaxMind.Db.Benchmark", "Max
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MaxMind.Db.Test", "MaxMind.Db.Test\MaxMind.Db.Test.csproj", "{15A04FFF-BCC5-45F9-84E2-AB51B567E3E9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MaxMind.Db.NativeAot.Test", "MaxMind.Db.NativeAot.Test\MaxMind.Db.NativeAot.Test.csproj", "{BECF3189-DFD7-43E3-8269-D4ED8D315D81}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{F1051D87-38BE-4E9C-B7B3-9FA2DFB4FB56}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F1051D87-38BE-4E9C-B7B3-9FA2DFB4FB56}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F1051D87-38BE-4E9C-B7B3-9FA2DFB4FB56}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BECF3189-DFD7-43E3-8269-D4ED8D315D81}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BECF3189-DFD7-43E3-8269-D4ED8D315D81}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BECF3189-DFD7-43E3-8269-D4ED8D315D81}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BECF3189-DFD7-43E3-8269-D4ED8D315D81}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MaxMind.Db/Reader.cs
+++ b/MaxMind.Db/Reader.cs
@@ -2,6 +2,9 @@
 
 using System;
 using System.Collections.Generic;
+#if NET
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
@@ -138,6 +141,11 @@ namespace MaxMind.Db
         {
         }
 
+#if NET
+        // Metadata is instantiated through the reflection-based decoder. Keep its
+        // attributed constructor when the reader is trimmed or compiled with Native AOT.
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors, typeof(Metadata))]
+#endif
         private Reader(MemoryMapBuffer buffer, string? file)
         {
             _fileName = file;


### PR DESCRIPTION
# Preserve metadata constructor for Native AOT

## Summary

- Preserve the `Metadata` constructor used by the reflection-based decoder
  when trimming or compiling with Native AOT.
- Add a Native AOT smoke application that opens the decoder test database and
  performs a lookup.
- Publish and execute the native smoke application in GitHub Actions.

This is intentionally a narrow runtime correctness fix. It does not mark
`MaxMind.Db` as AOT-compatible and does not suppress the remaining analyzer
warnings in the general model materialization path. A separate design issue
proposes a statically analyzable descriptor/source-generation path: #321.

## Verification

- Solution build passes.
- Existing .NET 8 tests pass.
- `dotnet publish` with `PublishAot=true` succeeds for `linux-x64`.
- The published native executable opens the test database and validates a
  decoded record.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Native AOT builds and runtime verification.
  * Native AOT testing now validates database lookups and Unicode data handling.

* **Bug Fixes**
  * Improved compatibility with trimming and Native AOT scenarios by preserving required metadata during decoding.

* **Tests**
  * Added automated CI coverage for Native AOT publishing and execution.
  * Code scanning now includes Git submodule contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->