### PR TITLE
Validate package API against the latest release

### DIFF
--- a/MaxMind.Db/MaxMind.Db.csproj
+++ b/MaxMind.Db/MaxMind.Db.csproj
@@ -16,6 +16,7 @@
     <PackageProjectUrl>https://github.com/maxmind/MaxMind-DB-Reader-dotnet</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>5.1.0</PackageValidationBaselineVersion>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/maxmind/MaxMind-DB-Reader-dotnet</RepositoryUrl>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/dev-bin/release.sh
+++ b/dev-bin/release.sh
@@ -110,3 +110,12 @@ git commit -m "Prepare for $version" -a
 git push
 
 gh release create --target "$(git branch --show-current)" -t "$version" -n "$notes" "$tag"
+
+# Now that the release is tagged, validate future changes against it. The
+# package may not be downloadable from NuGet until several minutes after
+# the release workflow publishes it.
+sed -i "s|<PackageValidationBaselineVersion>[^<]*</PackageValidationBaselineVersion>|<PackageValidationBaselineVersion>$version</PackageValidationBaselineVersion>|" MaxMind.Db/MaxMind.Db.csproj
+
+git commit -m "Set package validation baseline to $version" -a
+
+git push


### PR DESCRIPTION
## What

Set `PackageValidationBaselineVersion` to 5.1.0 (the latest published release) in `MaxMind.Db.csproj`, and update `dev-bin/release.sh` to bump the baseline to the new version right after tagging a release.

## Why

`EnablePackageValidation` (already set) only runs the compatible-TFM validators on its own; it does not compare the package against the previously published release, so an accidental breaking API change still packs successfully. With `PackageValidationBaselineVersion` set, `dotnet pack` downloads the baseline package from NuGet and fails on binary- or source-incompatible changes. Since the release workflow runs `dotnet pack` on every pull request, accidental breaking changes are caught in CI (STF-55).

The baseline is bumped *after* tagging so that pull requests are always validated against the latest published release, while the tagged commit itself is validated against the release it replaces (the new version is not yet on NuGet when the release build packs). One caveat: packs that run in the few minutes between tagging and the package becoming downloadable from NuGet can fail transiently; a re-run fixes them.

Verified locally: `dotnet pack` on this branch passes against the 5.1.0 baseline, and in a sibling repo an intentional breaking change (making a public property internal) fails pack with `CP0002` for every TFM. Intentional breaking changes (e.g., for a future major release) can be recorded with `dotnet pack /p:ApiCompatGenerateSuppressionFile=true`.

Same change as maxmind/minfraud-api-dotnet#445 and maxmind/GeoIP2-dotnet#508.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package validation to use the correct baseline version.
  * Automated baseline updates after creating a release, including committing and pushing the new version.
* **Refactor**
  * Improved the release workflow to keep package validation aligned with newly published versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->