### PR TITLE
Bound decoder work to prevent a pointer fan-out DoS (STF-1572)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,14 +35,14 @@ dotnet build MaxMind.Db.sln
 
 ```bash
 # Run all tests
-dotnet test MaxMind.Db.Test/MaxMind.Db.Test.csproj
+dotnet test --project MaxMind.Db.Test/MaxMind.Db.Test.csproj
 
 # Run specific test class
-dotnet test --filter "FullyQualifiedName~ReaderTest"
-dotnet test --filter "FullyQualifiedName~DecoderTest"
+dotnet test --project MaxMind.Db.Test/MaxMind.Db.Test.csproj -- --filter-class "*ReaderTest"
+dotnet test --project MaxMind.Db.Test/MaxMind.Db.Test.csproj -- --filter-class "*DecoderTest"
 
 # Run specific test method
-dotnet test --filter "FullyQualifiedName~ReaderTest.TestMany"
+dotnet test --project MaxMind.Db.Test/MaxMind.Db.Test.csproj -- --filter-method "*ReaderTest.TestPointerHeavyValueCountDecodes"
 ```
 
 ### Running Benchmarks

--- a/MaxMind.Db.Benchmark/Program.cs
+++ b/MaxMind.Db.Benchmark/Program.cs
@@ -7,7 +7,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Net;
 
-BenchmarkRunner.Run<CityBenchmark>();
+BenchmarkRunner.Run<CityBenchmark>(args: args);
 
 [MemoryDiagnoser]
 public class CityBenchmark

--- a/MaxMind.Db.Test/CollectionActivatorTest.cs
+++ b/MaxMind.Db.Test/CollectionActivatorTest.cs
@@ -29,6 +29,9 @@ namespace MaxMind.Db.Test
             var factory = new DictionaryActivatorCreator().GetActivator(typeof(IDictionary<string, long>));
             var dictionary = Assert.IsType<Dictionary<string, long>>(factory(123));
             Assert.Empty(dictionary);
+#if NET8_0_OR_GREATER
+            Assert.True(dictionary.EnsureCapacity(0) >= 123);
+#endif
             dictionary.Add("value", 7);
             Assert.Equal(7, dictionary["value"]);
         }

--- a/MaxMind.Db.Test/CollectionActivatorTest.cs
+++ b/MaxMind.Db.Test/CollectionActivatorTest.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace MaxMind.Db.Test
+{
+    public static class CollectionActivatorTest
+    {
+        [Fact]
+        public static void ListFactoryUsesRequestedCapacity()
+        {
+            var factory = new ListActivatorCreator().GetActivator(typeof(ICollection<long>));
+            var list = Assert.IsType<List<long>>(factory(123));
+            Assert.Empty(list);
+            Assert.Equal(123, list.Capacity);
+        }
+
+        [Fact]
+        public static void ListFactoryPreservesCustomDefaultConstructor()
+        {
+            var factory = new ListActivatorCreator().GetActivator(typeof(DefaultList<long>));
+            var list = Assert.IsType<DefaultList<long>>(factory(123));
+            Assert.True(list.WasConstructed);
+            Assert.Equal(0, list.Capacity);
+        }
+
+        [Fact]
+        public static void DictionaryFactoryCreatesRequestedInterface()
+        {
+            var factory = new DictionaryActivatorCreator().GetActivator(typeof(IDictionary<string, long>));
+            var dictionary = Assert.IsType<Dictionary<string, long>>(factory(123));
+            Assert.Empty(dictionary);
+            dictionary.Add("value", 7);
+            Assert.Equal(7, dictionary["value"]);
+        }
+
+        [Fact]
+        public static void DictionaryFactoryPreservesCustomDefaultConstructor()
+        {
+            var factory = new DictionaryActivatorCreator().GetActivator(typeof(DefaultDictionary<string, long>));
+            var dictionary = Assert.IsType<DefaultDictionary<string, long>>(factory(123));
+            Assert.True(dictionary.WasConstructed);
+            Assert.Empty(dictionary);
+        }
+
+        private sealed class DefaultList<T> : List<T>
+        {
+            public DefaultList()
+            {
+                WasConstructed = true;
+            }
+
+            public bool WasConstructed { get; }
+        }
+
+        private sealed class DefaultDictionary<TKey, TValue> : Dictionary<TKey, TValue> where TKey : notnull
+        {
+            public DefaultDictionary()
+            {
+                WasConstructed = true;
+            }
+
+            public bool WasConstructed { get; }
+        }
+    }
+}

--- a/MaxMind.Db.Test/DecoderTest.cs
+++ b/MaxMind.Db.Test/DecoderTest.cs
@@ -634,58 +634,144 @@ namespace MaxMind.Db.Test
             Assert.Equal(bytes.Length, offset);
         }
 
-        [Fact]
-        public static void TestWideIntegerConsumesPayloadBudget()
+        [Theory]
+        [InlineData(6, 4)]
+        [InlineData(9, 8)]
+        [InlineData(10, 16)]
+        public static void TestIntegerWidthBoundaries(int type, int maximumSize)
         {
-            // DecodeBigInteger calls ConsumePayload before ReadBigInteger
-            // copies the declared bytes into a new array. An oversized
-            // uint128 must be charged against the payload budget before the
-            // copy. This declares a size one byte over the 2 MiB budget with
-            // no body. An early charge reports the payload limit. A late
-            // charge would instead read past the end and report truncation.
-            // 0x1f selects the extended type with size code 31 (three size
-            // bytes). 0x03 is the extended type byte for uint128
-            // (ObjectType.Uint128 - 7). The size bytes encode
-            // 2,097,153 - 65,821 = 2,031,332 (0x1efee4).
-            using var database = new MemoryMapBuffer(
-                new MemoryStream([0x1f, 0x03, 0x1e, 0xfe, 0xe4], writable: false));
-            var decoder = new Decoder(database, 0);
-            var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(0, out _));
-            Assert.Contains("maximum payload size", ex.Message);
+            foreach (var size in new[] { 0, maximumSize })
+            {
+                var bytes = EncodedInteger(type, size, size);
+                bytes.Add(0xA0); // next value: uint16 zero
+                using var database = new MemoryMapBuffer(new MemoryStream(bytes.ToArray(), writable: false));
+                var decoder = new Decoder(database, 0);
+                var value = decoder.Decode<object>(0, out var offset);
+                var expected = (BigInteger.One << (size * 8)) - 1;
+                if (type == 6)
+                {
+                    Assert.Equal((long)expected, Assert.IsType<long>(value));
+                }
+                else if (type == 9)
+                {
+                    Assert.Equal((ulong)expected, Assert.IsType<ulong>(value));
+                }
+                else
+                {
+                    Assert.Equal(expected, Assert.IsType<BigInteger>(value));
+                }
+                Assert.Equal(bytes.Count - 1, offset);
+                Assert.Equal(0, Assert.IsType<int>(decoder.Decode<object>(offset, out offset)));
+                Assert.Equal(bytes.Count, offset);
+            }
         }
 
-        [Fact]
-        public static void TestUint32ConsumesPayloadBudget()
+        [Theory]
+        [InlineData(6, 4)]
+        [InlineData(9, 8)]
+        [InlineData(10, 16)]
+        public static void TestOversizedIntegerRejectsBeforeReading(int type, int maximumSize)
         {
-            // DecodeLong shares ConsumePayload's call pattern with
-            // DecodeBigInteger: it charges the declared length before
-            // ReadLong reads it. This is the same shape as
-            // TestWideIntegerConsumesPayloadBudget, for a uint32 instead of
-            // a uint128. Uint32 (type 6) is a direct type, so no extended
-            // type byte is needed: 0xdf is uint32 with size code 31 (three
-            // size bytes). The size bytes encode the same one-byte-over
-            // length, 2,097,153 - 65,821 = 2,031,332 (0x1efee4).
-            using var database = new MemoryMapBuffer(
-                new MemoryStream([0xdf, 0x1e, 0xfe, 0xe4], writable: false));
-            var decoder = new Decoder(database, 0);
-            var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(0, out _));
-            Assert.Contains("maximum payload size", ex.Message);
+            foreach (var payloadSize in new[] { 0, maximumSize + 1 })
+            {
+                var bytes = EncodedInteger(type, maximumSize + 1, payloadSize);
+                using var database = new MemoryMapBuffer(new MemoryStream(bytes.ToArray(), writable: false));
+                var decoder = new Decoder(database, 0);
+                var error = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(0, out _));
+                Assert.Contains($"larger than {maximumSize} bytes", error.Message);
+            }
         }
 
-        [Fact]
-        public static void TestUint64ConsumesPayloadBudget()
+        [Theory]
+        [InlineData(6, 4)]
+        [InlineData(9, 8)]
+        [InlineData(10, 16)]
+        public static void TestIntegerSizeLimitPrecedesPayloadLimit(int type, int maximumSize)
         {
-            // Same shape as TestWideIntegerConsumesPayloadBudget, for
-            // DecodeUInt64. 0x1f selects the extended type with size code
-            // 31 (three size bytes). 0x02 is the extended type byte for
-            // uint64 (ObjectType.Uint64 - 7). The size bytes encode the
-            // same one-byte-over length, 2,097,153 - 65,821 = 2,031,332
-            // (0x1efee4).
-            using var database = new MemoryMapBuffer(
-                new MemoryStream([0x1f, 0x02, 0x1e, 0xfe, 0xe4], writable: false));
+            // Declare 2 MiB + 1 bytes without a body. Reject the width before
+            // charging payload or attempting a read.
+            var bytes = new List<byte>();
+            if (type == 6)
+            {
+                bytes.Add(0xDF);
+            }
+            else
+            {
+                bytes.Add(0x1F);
+                bytes.Add((byte)(type - 7));
+            }
+            bytes.AddRange([0x1E, 0xFE, 0xE4]);
+            using var database = new MemoryMapBuffer(new MemoryStream(bytes.ToArray(), writable: false));
             var decoder = new Decoder(database, 0);
-            var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(0, out _));
-            Assert.Contains("maximum payload size", ex.Message);
+            var error = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(0, out _));
+            Assert.Contains($"larger than {maximumSize} bytes", error.Message);
+        }
+
+        [Theory]
+        [InlineData(6, 4)]
+        [InlineData(9, 8)]
+        [InlineData(10, 16)]
+        public static void TestValidIntegerSharesPayloadBudgetWithString(int type, int maximumSize)
+        {
+            foreach (var exceedsLimit in new[] { false, true })
+            {
+                foreach (var stringFirst in new[] { false, true })
+                {
+                    var stringSize = (1 << 21) - maximumSize;
+                    if (exceedsLimit)
+                    {
+                        stringSize++;
+                    }
+                    var encodedSize = stringSize - 65821;
+                    var text = new List<byte> { 0x5F, (byte)(encodedSize >> 16), (byte)(encodedSize >> 8), (byte)encodedSize };
+                    text.AddRange(Encoding.UTF8.GetBytes(new string('a', stringSize)));
+                    var integer = EncodedInteger(type, maximumSize, maximumSize);
+                    var bytes = new List<byte> { 0x02, 0x04 }; // array of two values
+                    if (stringFirst)
+                    {
+                        bytes.AddRange(text);
+                        bytes.AddRange(integer);
+                    }
+                    else
+                    {
+                        bytes.AddRange(integer);
+                        bytes.AddRange(text);
+                    }
+                    using var database = new MemoryMapBuffer(new MemoryStream(bytes.ToArray(), writable: false));
+                    var decoder = new Decoder(database, 0);
+                    if (exceedsLimit)
+                    {
+                        var error = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(0, out _));
+                        Assert.Contains("maximum payload size", error.Message);
+                    }
+                    else
+                    {
+                        var values = Assert.IsType<List<object>>(decoder.Decode<object>(0, out var offset));
+                        Assert.Equal(2, values.Count);
+                        Assert.Contains(values, value => value is string textValue && textValue.Length == stringSize);
+                        Assert.Equal(bytes.Count, offset);
+                    }
+                }
+            }
+        }
+
+        private static List<byte> EncodedInteger(int type, int size, int payloadSize)
+        {
+            var bytes = new List<byte>();
+            if (type == 6)
+            {
+                bytes.Add((byte)(0xC0 | size));
+            }
+            else
+            {
+                bytes.Add((byte)size);
+                bytes.Add((byte)(type - 7));
+            }
+            for (var i = 0; i < payloadSize; i++)
+            {
+                bytes.Add(0xFF);
+            }
+            return bytes;
         }
 
         public static IEnumerable<object[]> TestUInt16()

--- a/MaxMind.Db.Test/DecoderTest.cs
+++ b/MaxMind.Db.Test/DecoderTest.cs
@@ -70,37 +70,10 @@ namespace MaxMind.Db.Test
         }
 
         [Fact]
-        public static void TestPointerFanOutIsBounded()
-        {
-            // A data section of nested arrays, each holding two pointers to the
-            // node below, would cost 2**depth decode operations. The decoder
-            // bounds the number of values it decodes per lookup and rejects the
-            // database.
-            const int depth = 100;
-            var bytes = new List<byte> { 0xA0 }; // leaf: uint16 with value 0
-            var prev = 0;
-            for (var i = 0; i < depth; i++)
-            {
-                var offset = bytes.Count;
-                bytes.Add(0x02);
-                bytes.Add(0x04);
-                WritePointer1(bytes, prev);
-                WritePointer1(bytes, prev);
-                prev = offset;
-            }
-
-            using var database = new MemoryMapBuffer(new MemoryStream(bytes.ToArray(), writable: false));
-            var decoder = new Decoder(database, 0);
-            var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(prev, out _));
-            Assert.Contains("maximum number of values", ex.Message);
-        }
-
-        [Fact]
         public static void TestMapPointerFanOutIsBounded()
         {
-            // Each map has two distinct keys whose values point to the map
-            // below. Re-decoding the shared targets must consume the map's two
-            // key/value pairs from the value budget on every visit.
+            // Both map values point to the same child. Each visit must
+            // charge the child map again.
             const int depth = 100;
             var bytes = new List<byte> { 0xA0 }; // leaf: uint16 with value 0
             var prev = 0;
@@ -123,23 +96,34 @@ namespace MaxMind.Db.Test
             Assert.Contains("maximum number of values", ex.Message);
         }
 
+        // 256 bytes of string payload per pointer target. 8,192 occurrences
+        // reach exactly the 2 MiB payload budget and 8,193 cross it.
+        private const int FlatFanOutTargetSize = 256;
+
         [Theory]
-        [InlineData(32_768, false)]
-        [InlineData(32_769, true)]
-        public static void TestFlatScalarPointerTargetsConsumeValueBudget(int pointerCount, bool exceedsLimit)
+        [InlineData(8_192, false)]
+        [InlineData(8_193, true)]
+        public static void TestFlatScalarPointerTargetsConsumePayloadBudget(int pointerCount, bool exceedsLimit)
         {
-            // The array charges each pointer field, and following each pointer
-            // charges its scalar target. At 32,768 pointers the two charges use
-            // the full 65,536-value budget. One more must be rejected. This is
-            // intentionally flat so neither depth nor exponential fan-out can
-            // hide incorrect target accounting.
+            // Many pointers to one string value is a flat fan-out. The value
+            // budget cannot bound it, because the array charges each pointer
+            // once and following a pointer adds no value of its own. The
+            // payload budget bounds it instead: it charges the target length on
+            // every occurrence, so the copied bytes stay under 2 MiB. This is
+            // intentionally flat so neither depth nor exponential container
+            // fan-out can hide incorrect payload accounting.
             var encodedSize = pointerCount - 285;
-            var bytes = new List<byte>(pointerCount * 2 + 5)
+            var bytes = new List<byte>(pointerCount * 2 + FlatFanOutTargetSize + 8)
             {
-                0x40, // target: empty UTF-8 string
-                0x1E, 0x04, // array with a two-byte encoded size
-                (byte)(encodedSize >> 8), (byte)encodedSize,
+                0x5D, // target: UTF-8 string with a one-byte encoded size
+                (byte)(FlatFanOutTargetSize - 29),
             };
+            bytes.AddRange(new byte[FlatFanOutTargetSize]);
+            var arrayOffset = bytes.Count;
+            bytes.Add(0x1E);
+            bytes.Add(0x04); // array with a two-byte encoded size
+            bytes.Add((byte)(encodedSize >> 8));
+            bytes.Add((byte)encodedSize);
             for (var i = 0; i < pointerCount; i++)
             {
                 WritePointer1(bytes, 0);
@@ -149,36 +133,37 @@ namespace MaxMind.Db.Test
             var decoder = new Decoder(database, 0);
             if (exceedsLimit)
             {
-                var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(1, out _));
+                var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(arrayOffset, out _));
                 Assert.Equal(
-                    "The MaxMind DB file's data section exceeds the maximum number of values.",
+                    "The MaxMind DB file's data section exceeds the maximum payload size.",
                     ex.Message);
             }
             else
             {
-                var decoded = Assert.IsType<List<object>>(decoder.Decode<object>(1, out var offset));
+                var decoded = Assert.IsType<List<object>>(decoder.Decode<object>(arrayOffset, out var offset));
                 Assert.Equal(pointerCount, decoded.Count);
                 Assert.Equal(bytes.Count, offset);
             }
         }
 
         [Theory]
-        [InlineData(21_845, false)]
-        [InlineData(21_846, true)]
-        public static void TestFlatModelKeyPointerTargetsConsumeValueBudget(int pointerCount, bool exceedsLimit)
+        [InlineData(8_192, false)]
+        [InlineData(8_193, true)]
+        public static void TestFlatModelKeyPointerTargetsConsumePayloadBudget(int pointerCount, bool exceedsLimit)
         {
-            // A map charges its key and value fields, and following each key
-            // pointer charges the UTF-8 target that DecodeKey hashes. At 21,845
-            // entries those charges use 65,535 values. One more entry crosses
-            // the limit. Empty keys are unknown to KeyOnlyModel, so their false
-            // values are skipped without introducing another pointer path.
+            // DecodeKey must charge each visit to the shared key. Unknown
+            // fields have false values, so skipping them adds no payload charge.
             var encodedSize = pointerCount - 285;
-            var bytes = new List<byte>(pointerCount * 4 + 4)
+            var bytes = new List<byte>(pointerCount * 4 + FlatFanOutTargetSize + 8)
             {
-                0x40, // target: empty UTF-8 string
-                0xFE, // map with a two-byte encoded size
-                (byte)(encodedSize >> 8), (byte)encodedSize,
+                0x5D, // target: UTF-8 string with a one-byte encoded size
+                (byte)(FlatFanOutTargetSize - 29),
             };
+            bytes.AddRange(new byte[FlatFanOutTargetSize]);
+            var mapOffset = bytes.Count;
+            bytes.Add(0xFE); // map with a two-byte encoded size
+            bytes.Add((byte)(encodedSize >> 8));
+            bytes.Add((byte)encodedSize);
             for (var i = 0; i < pointerCount; i++)
             {
                 WritePointer1(bytes, 0);
@@ -190,14 +175,14 @@ namespace MaxMind.Db.Test
             var decoder = new Decoder(database, 0);
             if (exceedsLimit)
             {
-                var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<KeyOnlyModel>(1, out _));
+                var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<KeyOnlyModel>(mapOffset, out _));
                 Assert.Equal(
-                    "The MaxMind DB file's data section exceeds the maximum number of values.",
+                    "The MaxMind DB file's data section exceeds the maximum payload size.",
                     ex.Message);
             }
             else
             {
-                var decoded = decoder.Decode<KeyOnlyModel>(1, out var offset);
+                var decoded = decoder.Decode<KeyOnlyModel>(mapOffset, out var offset);
                 Assert.Null(decoded.Name);
                 Assert.Equal(bytes.Count, offset);
             }
@@ -230,11 +215,12 @@ namespace MaxMind.Db.Test
         [Fact]
         public static void TestCyclicPointerThrows()
         {
-            // A pointer to itself must throw a catchable InvalidDatabaseException
-            // rather than recursing until the stack overflows.
+            // A pointer cycle has no container charges. The depth guard
+            // must stop it with a catchable database exception.
             using var database = new MemoryMapBuffer(new MemoryStream([0x20, 0x00], writable: false));
             var decoder = new Decoder(database, 0);
-            Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(0, out _));
+            var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(0, out _));
+            Assert.Contains("maximum depth", ex.Message);
         }
 
         private sealed class KeyOnlyModel
@@ -306,15 +292,12 @@ namespace MaxMind.Db.Test
         [Fact]
         public static void TestCyclicPointerAsMapKeyThrows()
         {
-            // Decoding into a model type reads map keys through a separate path
-            // (DecodeKey) from the dictionary path. A key that is a pointer to
-            // itself must also throw a catchable InvalidDatabaseException rather
-            // than overflowing the stack.
-            // 0xe1: map with one entry. The key at offset 1 is a one-byte
-            // pointer (0x20 0x01) whose target is offset 1, the pointer itself.
+            // Model keys use DecodeKey rather than the dictionary path.
+            // The key pointer at offset 1 targets itself.
             using var database = new MemoryMapBuffer(new MemoryStream([0xe1, 0x20, 0x01], writable: false));
             var decoder = new Decoder(database, 0);
-            Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<KeyOnlyModel>(0, out _));
+            var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<KeyOnlyModel>(0, out _));
+            Assert.Contains("maximum depth", ex.Message);
         }
 
         [Fact]

--- a/MaxMind.Db.Test/DecoderTest.cs
+++ b/MaxMind.Db.Test/DecoderTest.cs
@@ -332,12 +332,11 @@ namespace MaxMind.Db.Test
         [Fact]
         public static void TestCyclicPointerThrows()
         {
-            // A pointer cycle has no container charges. The depth guard
-            // must stop it with a catchable database exception.
+            // Reject a self-pointer before following it again.
             using var database = new MemoryMapBuffer(new MemoryStream([0x20, 0x00], writable: false));
             var decoder = new Decoder(database, 0);
             var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(0, out _));
-            Assert.Contains("maximum depth", ex.Message);
+            Assert.Contains("pointer to another pointer", ex.Message);
         }
 
         private sealed class KeyOnlyModel
@@ -408,8 +407,8 @@ namespace MaxMind.Db.Test
 
         [Theory]
         [InlineData(1, false)]
-        [InlineData(2, false)]
-        [InlineData(511, false)]
+        [InlineData(2, true)]
+        [InlineData(511, true)]
         [InlineData(512, true)]
         public static void TestMapKeyPointerChainPreservesValueOffset(int pointerCount, bool exceedsLimit)
         {
@@ -433,7 +432,7 @@ namespace MaxMind.Db.Test
             if (exceedsLimit)
             {
                 var error = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<KeyOnlyModel>(mapOffset, out _));
-                Assert.Contains("maximum depth", error.Message);
+                Assert.Contains("pointer to another pointer", error.Message);
             }
             else
             {
@@ -451,7 +450,7 @@ namespace MaxMind.Db.Test
             using var database = new MemoryMapBuffer(new MemoryStream([0xe1, 0x20, 0x01], writable: false));
             var decoder = new Decoder(database, 0);
             var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<KeyOnlyModel>(0, out _));
-            Assert.Contains("maximum depth", ex.Message);
+            Assert.Contains("pointer to another pointer", ex.Message);
         }
 
         // These headers declare oversized values without a body. Expect
@@ -533,54 +532,115 @@ namespace MaxMind.Db.Test
         }
 
         [Theory]
-        [InlineData(511, false)]
-        [InlineData(512, false)]
-        [InlineData(513, true)]
-        public static void TestPointerChainDepthIsBounded(int chainLength, bool exceedsLimit)
+        [InlineData(1, false)]
+        [InlineData(2, true)]
+        [InlineData(512, true)]
+        public static void TestPointerToPointerIsRejected(int chainLength, bool invalid)
         {
-            // A chain of 512 pointer follows is allowed. The 513th follow
-            // exceeds the depth limit.
             var bytes = PointerChain(chainLength);
             using var database = new MemoryMapBuffer(new MemoryStream(bytes, writable: false));
             var decoder = new Decoder(database, 0);
-
-            if (exceedsLimit)
+            if (invalid)
             {
-                var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(0, out _));
-                Assert.Equal("The MaxMind DB file's data section exceeds the maximum depth.", ex.Message);
+                var error = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(0, out _));
+                Assert.Contains("pointer to another pointer", error.Message);
             }
             else
             {
-                Assert.Equal(0, Assert.IsType<int>(decoder.Decode<object>(0, out _)));
+                Assert.Equal(0, Assert.IsType<int>(decoder.Decode<object>(0, out var offset)));
+                Assert.Equal(2, offset);
             }
         }
 
-        [Fact]
-        public static void TestDepthAccumulatesAcrossContainerIntoPointerChain()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public static void TestTwoNodePointerCycleIsRejected(bool mapKey)
         {
-            // The array element adds one pointer to a 511-link chain.
-            // Those 512 follows succeed at root depth but exceed the limit
-            // when the array contributes one level. Give the thread enough
-            // stack to test the depth limit without a runtime stack rejection.
-            var chain = PointerChain(511);
-            var arrayOffset = chain.Length;
-            var bytes = new List<byte>(chain.Length + 4);
-            bytes.AddRange(chain);
-            bytes.Add(0x01); // extended type, size 1
-            bytes.Add(0x04); // extended type byte: array (11 - 7)
-            var pointerOffset = bytes.Count;
-            WritePointer1(bytes, 0);
-            Exception? failure = null;
+            var bytes = new List<byte> { 0x20, 0x02, 0x20, 0x00, 0xE1, 0x20, 0x00 };
+            using var database = new MemoryMapBuffer(new MemoryStream(bytes.ToArray(), writable: false));
+            var decoder = new Decoder(database, 0);
+            var error = Assert.Throws<InvalidDatabaseException>(() =>
+            {
+                if (mapKey)
+                {
+                    decoder.Decode<KeyOnlyModel>(4, out _);
+                }
+                else
+                {
+                    decoder.Decode<object>(0, out _);
+                }
+            });
+            Assert.Contains("pointer to another pointer", error.Message);
+        }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public static void TestPointerTargetIsRejectedBeforeReadingItsPayload(bool mapKey)
+        {
+            byte[] bytes;
+            if (mapKey)
+            {
+                bytes = [0xE1, 0x20, 0x03, 0x20];
+            }
+            else
+            {
+                bytes = [0x20, 0x02, 0x20];
+            }
+            using var database = new MemoryMapBuffer(new MemoryStream(bytes, writable: false));
+            var decoder = new Decoder(database, 0);
+            var error = Assert.Throws<InvalidDatabaseException>(() =>
+            {
+                if (mapKey)
+                {
+                    decoder.Decode<KeyOnlyModel>(0, out _);
+                }
+                else
+                {
+                    decoder.Decode<object>(0, out _);
+                }
+            });
+            Assert.Contains("pointer to another pointer", error.Message);
+        }
+
+        [Theory]
+        [InlineData(255, false)]
+        [InlineData(256, false)]
+        [InlineData(257, true)]
+        public static void TestDepthAccumulatesAcrossPointersToContainers(int count, bool exceedsLimit)
+        {
+            // Every pointer targets a one-element array. Each pair costs two
+            // levels, and no pointer directly targets another pointer.
+            var bytes = new List<byte>();
+            for (var i = 0; i < count; i++)
+            {
+                WritePointer1(bytes, bytes.Count + 2);
+                bytes.AddRange([0x01, 0x04]);
+            }
+            bytes.Add(0xA0);
+            Exception? failure = null;
             var thread = new Thread(() =>
             {
                 try
                 {
                     using var database = new MemoryMapBuffer(new MemoryStream(bytes.ToArray(), writable: false));
                     var decoder = new Decoder(database, 0);
-                    Assert.Equal(0, Assert.IsType<int>(decoder.Decode<object>(pointerOffset, out _)));
-                    var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(arrayOffset, out _));
-                    Assert.Equal("The MaxMind DB file's data section exceeds the maximum depth.", ex.Message);
+                    if (exceedsLimit)
+                    {
+                        var error = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(0, out _));
+                        Assert.Contains("maximum depth", error.Message);
+                    }
+                    else
+                    {
+                        object value = decoder.Decode<object>(0, out var offset);
+                        Assert.Equal(2, offset);
+                        for (var i = 0; i < count; i++)
+                        {
+                            value = Assert.Single(Assert.IsType<List<object>>(value));
+                        }
+                        Assert.Equal(0, Assert.IsType<int>(value));
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -589,7 +649,6 @@ namespace MaxMind.Db.Test
             }, maxStackSize: 16 << 20);
             thread.Start();
             thread.Join();
-
             if (failure != null)
             {
                 ExceptionDispatchInfo.Capture(failure).Throw();
@@ -618,20 +677,18 @@ namespace MaxMind.Db.Test
         }
 
         [Fact]
-        public static void TestManySlotsEachFollowingALongPointerChainTerminates()
+        public static void TestManySlotsEachFollowingALongPointerChainIsRejected()
         {
-            // Each slot adds one pointer before the 300-link chain: 301,000
-            // follows in total. The root and slots cost 1,001 values, and the
-            // leaf is reached at depth 302, within both limits.
-            const int slotCount = 1_000;
-            const int chainLength = 300;
+            // A shared chain could previously amplify one lookup into tens
+            // of millions of pointer follows while staying within the limits.
+            const int slotCount = 65_534;
+            const int chainLength = 509;
             var bytes = ManySlotsEachFollowingALongPointerChain(slotCount, chainLength, out var arrayOffset);
             using var database = new MemoryMapBuffer(new MemoryStream(bytes, writable: false));
             var decoder = new Decoder(database, 0);
 
-            var decoded = Assert.IsType<List<object>>(decoder.Decode<object>(arrayOffset, out var offset));
-            Assert.Equal(slotCount, decoded.Count);
-            Assert.Equal(bytes.Length, offset);
+            var error = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(arrayOffset, out _));
+            Assert.Contains("pointer to another pointer", error.Message);
         }
 
         [Theory]
@@ -925,6 +982,84 @@ namespace MaxMind.Db.Test
             };
 
             yield return [floats];
+        }
+
+        [Theory]
+        [InlineData(1, false)]
+        [InlineData(2, false)]
+        [InlineData(3, false)]
+        [InlineData(4, false)]
+        [InlineData(1, true)]
+        [InlineData(2, true)]
+        [InlineData(3, true)]
+        [InlineData(4, true)]
+        public static void TestPointerWidthsPreserveValueAndOffset(int width, bool mapKey)
+        {
+            // Use the smallest encoded target that leaves room for the record.
+            // Two- and three-byte pointers have an implicit offset added.
+            var target = 16;
+            if (width == 2)
+            {
+                target += 1 << 11;
+            }
+            else if (width == 3)
+            {
+                target += (1 << 19) + (1 << 11);
+            }
+            var bytes = new byte[target + 5];
+            bytes[0] = 0xA0; // scalar target for the pointer inside the array
+            var start = 1;
+            if (mapKey)
+            {
+                bytes[start++] = 0xE1;
+            }
+            bytes[start] = (byte)(0x20 | ((width - 1) << 3));
+            bytes[start + width] = 16;
+            var end = start + width + 1;
+            if (mapKey)
+            {
+                bytes[end++] = 0x43;
+                bytes[end++] = (byte)'v';
+                bytes[end++] = (byte)'a';
+                bytes[end++] = (byte)'l';
+                new byte[] { 0x44, (byte)'n', (byte)'a', (byte)'m', (byte)'e' }.CopyTo(bytes, target);
+            }
+            else
+            {
+                // A pointer to a container containing a pointer remains valid.
+                new byte[] { 0x01, 0x04, 0x20, 0x00 }.CopyTo(bytes, target);
+            }
+            using var database = new MemoryMapBuffer(new MemoryStream(bytes, writable: false));
+            var decoder = new Decoder(database, 0);
+            if (mapKey)
+            {
+                var record = decoder.Decode<KeyOnlyModel>(1, out var offset);
+                Assert.Equal("val", record.Name);
+                Assert.Equal(end, offset);
+            }
+            else
+            {
+                var record = decoder.Decode<List<object>>(1, out var offset);
+                Assert.Equal(0, Assert.IsType<int>(Assert.Single(record)));
+                Assert.Equal(end, offset);
+            }
+            var rawDecoder = new Decoder(database, 0, false);
+            Assert.Equal((long)target, Assert.IsType<long>(rawDecoder.Decode<object>(start, out var rawOffset)));
+            Assert.Equal(start + width + 1, rawOffset);
+        }
+
+        [Fact]
+        public static void TestSkippedPointerDoesNotValidateItsTarget()
+        {
+            byte[] bytes = [0xE2, 0x44, (byte)'s', (byte)'k', (byte)'i', (byte)'p',
+                0x20, 17, 0x44, (byte)'n', (byte)'a', (byte)'m', (byte)'e',
+                0x43, (byte)'v', (byte)'a', (byte)'l', 0x20];
+            // The unknown field points at a pointer header with no payload.
+            using var database = new MemoryMapBuffer(new MemoryStream(bytes, writable: false));
+            var decoder = new Decoder(database, 0);
+            var record = decoder.Decode<KeyOnlyModel>(0, out var offset);
+            Assert.Equal("val", record.Name);
+            Assert.Equal(17, offset);
         }
 
         [Theory]

--- a/MaxMind.Db.Test/DecoderTest.cs
+++ b/MaxMind.Db.Test/DecoderTest.cs
@@ -102,18 +102,10 @@ namespace MaxMind.Db.Test
         // reach exactly the 2 MiB payload budget and 8,193 cross it.
         private const int FlatFanOutTargetSize = 256;
 
-        [Theory]
-        [InlineData(8_192, false)]
-        [InlineData(8_193, true)]
-        public static void TestFlatScalarPointerTargetsConsumePayloadBudget(int pointerCount, bool exceedsLimit)
+        // An array of pointers to one string isolates repeated payload
+        // charges from container fan-out and depth limits.
+        private static byte[] FlatScalarPointerTargets(int pointerCount, out int arrayOffset)
         {
-            // Many pointers to one string value is a flat fan-out. The value
-            // budget cannot bound it, because the array charges each pointer
-            // once and following a pointer adds no value of its own. The
-            // payload budget bounds it instead: it charges the target length on
-            // every occurrence, so the copied bytes stay under 2 MiB. This is
-            // intentionally flat so neither depth nor exponential container
-            // fan-out can hide incorrect payload accounting.
             var encodedSize = pointerCount - 285;
             var bytes = new List<byte>(pointerCount * 2 + FlatFanOutTargetSize + 8)
             {
@@ -121,7 +113,7 @@ namespace MaxMind.Db.Test
                 (byte)(FlatFanOutTargetSize - 29),
             };
             bytes.AddRange(new byte[FlatFanOutTargetSize]);
-            var arrayOffset = bytes.Count;
+            arrayOffset = bytes.Count;
             bytes.Add(0x1E);
             bytes.Add(0x04); // array with a two-byte encoded size
             bytes.Add((byte)(encodedSize >> 8));
@@ -131,7 +123,19 @@ namespace MaxMind.Db.Test
                 WritePointer1(bytes, 0);
             }
 
-            using var database = new MemoryMapBuffer(new MemoryStream(bytes.ToArray(), writable: false));
+            return [.. bytes];
+        }
+
+        [Theory]
+        [InlineData(8_192, false)]
+        [InlineData(8_193, true)]
+        public static void TestFlatScalarPointerTargetsConsumePayloadBudget(int pointerCount, bool exceedsLimit)
+        {
+            // This is intentionally flat so neither depth nor exponential
+            // container fan-out can hide incorrect payload accounting.
+            var bytes = FlatScalarPointerTargets(pointerCount, out var arrayOffset);
+
+            using var database = new MemoryMapBuffer(new MemoryStream(bytes, writable: false));
             var decoder = new Decoder(database, 0);
             if (exceedsLimit)
             {
@@ -142,9 +146,12 @@ namespace MaxMind.Db.Test
             }
             else
             {
-                var decoded = Assert.IsType<List<object>>(decoder.Decode<object>(arrayOffset, out var offset));
-                Assert.Equal(pointerCount, decoded.Count);
-                Assert.Equal(bytes.Count, offset);
+                for (var i = 0; i < 3; i++)
+                {
+                    var decoded = Assert.IsType<List<object>>(decoder.Decode<object>(arrayOffset, out var offset));
+                    Assert.Equal(pointerCount, decoded.Count);
+                    Assert.Equal(bytes.Length, offset);
+                }
             }
         }
 
@@ -188,6 +195,60 @@ namespace MaxMind.Db.Test
                 Assert.Null(decoded.Name);
                 Assert.Equal(bytes.Count, offset);
             }
+        }
+
+        // The root and 65,535 booleans use the entire value budget
+        // without consuming payload bytes.
+        private static byte[] AtValueBudgetLimitArray()
+        {
+            const int childCount = 65_535;
+            var encodedSize = childCount - 285;
+            var bytes = new List<byte>(childCount * 2 + 4)
+            {
+                0x1E, // array with a two-byte encoded size
+                0x04,
+                (byte)(encodedSize >> 8),
+                (byte)encodedSize,
+            };
+            for (var i = 0; i < childCount; i++)
+            {
+                bytes.Add(0x00); // extended boolean
+                bytes.Add(0x07); // false
+            }
+
+            return [.. bytes];
+        }
+
+        [Fact]
+        public static void TestManySimultaneousAtBudgetLimitDecodesSucceed()
+        {
+            // Exercise both budgets through one shared decoder. The repeated
+            // lookup tests check budget reset without relying on thread overlap.
+            const int pointerCount = 8_192;
+            const int childCount = 65_535;
+            var payloadBytes = FlatScalarPointerTargets(pointerCount, out var arrayOffset);
+            var valueBytes = AtValueBudgetLimitArray();
+            var valueOffset = payloadBytes.Length;
+            var bytes = new byte[payloadBytes.Length + valueBytes.Length];
+            payloadBytes.CopyTo(bytes, 0);
+            valueBytes.CopyTo(bytes, valueOffset);
+
+            using var database = new MemoryMapBuffer(new MemoryStream(bytes, writable: false));
+            var decoder = new Decoder(database, 0);
+
+            System.Threading.Tasks.Parallel.For(0, 16, i =>
+            {
+                if (i % 2 == 0)
+                {
+                    var decoded = Assert.IsType<List<object>>(decoder.Decode<object>(arrayOffset, out _));
+                    Assert.Equal(pointerCount, decoded.Count);
+                }
+                else
+                {
+                    var decoded = Assert.IsType<List<object>>(decoder.Decode<object>(valueOffset, out _));
+                    Assert.Equal(childCount, decoded.Count);
+                }
+            });
         }
 
         [Theory]

--- a/MaxMind.Db.Test/DecoderTest.cs
+++ b/MaxMind.Db.Test/DecoderTest.cs
@@ -927,6 +927,90 @@ namespace MaxMind.Db.Test
             yield return [floats];
         }
 
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        public static void TestFourBytePointerIgnoresLowControlBits(int lowBits)
+        {
+            byte[] bytes = [(byte)(0x38 | lowBits), 0, 0, 0, 5, 0xA1, 7];
+            using var database = new MemoryMapBuffer(new MemoryStream(bytes, writable: false));
+            var decoder = new Decoder(database, 0);
+            Assert.Equal(7, Assert.IsType<int>(decoder.Decode<object>(0, out var offset)));
+            Assert.Equal(5, offset);
+            var rawDecoder = new Decoder(database, 0, false);
+            Assert.Equal(5L, Assert.IsType<long>(rawDecoder.Decode<object>(0, out offset)));
+            Assert.Equal(5, offset);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        public static void TestFourByteMapKeyPointerPreservesValueOffset(int lowBits)
+        {
+            byte[] bytes = [0x44, (byte)'n', (byte)'a', (byte)'m', (byte)'e',
+                0xE1, (byte)(0x38 | lowBits), 0, 0, 0, 0,
+                0x43, (byte)'v', (byte)'a', (byte)'l'];
+            using var database = new MemoryMapBuffer(new MemoryStream(bytes, writable: false));
+            var decoder = new Decoder(database, 0);
+            var model = decoder.Decode<KeyOnlyModel>(5, out var offset);
+            Assert.Equal("val", model.Name);
+            Assert.Equal(bytes.Length, offset);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        public static void TestSkippedFourBytePointerPreservesNextField(int lowBits)
+        {
+            byte[] bytes = [0xE2, 0x41, (byte)'x', (byte)(0x38 | lowBits), 0, 0, 0, 0,
+                0x44, (byte)'n', (byte)'a', (byte)'m', (byte)'e',
+                0x43, (byte)'v', (byte)'a', (byte)'l'];
+            using var database = new MemoryMapBuffer(new MemoryStream(bytes, writable: false));
+            var decoder = new Decoder(database, 0);
+            var model = decoder.Decode<KeyOnlyModel>(0, out var offset);
+            Assert.Equal("val", model.Name);
+            Assert.Equal(bytes.Length, offset);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        public static void TestTruncatedFourBytePointerThrows(int lowBits)
+        {
+            for (var payloadSize = 0; payloadSize < 4; payloadSize++)
+            {
+                var bytes = new byte[payloadSize + 1];
+                bytes[0] = (byte)(0x38 | lowBits);
+                using var database = new MemoryMapBuffer(new MemoryStream(bytes, writable: false));
+                var decoder = new Decoder(database, 0, false);
+                Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(0, out _));
+            }
+        }
+
         public static IEnumerable<object[]> TestPointers()
         {
             var pointers = new Dictionary<object, byte[]>

--- a/MaxMind.Db.Test/DecoderTest.cs
+++ b/MaxMind.Db.Test/DecoderTest.cs
@@ -41,6 +41,282 @@ namespace MaxMind.Db.Test
             }
         }
 
+        private static void WritePointer1(List<byte> bytes, int target)
+        {
+            // One-byte-payload pointer (type 1, pointer_size 1) with base 0.
+            bytes.Add((byte)((1 << 5) | ((target >> 8) & 0x7)));
+            bytes.Add((byte)(target & 0xFF));
+        }
+
+        private static byte[] NestedContainers(int count)
+        {
+            var bytes = new List<byte>(count * 3 + 1);
+            for (var i = 0; i < count; i++)
+            {
+                if (i % 2 == 0)
+                {
+                    bytes.Add(0x01); // array with one element
+                    bytes.Add(0x04);
+                }
+                else
+                {
+                    bytes.Add(0xE1); // map with one entry
+                    bytes.Add(0x41); // one-byte string key
+                    bytes.Add((byte)'x');
+                }
+            }
+            bytes.Add(0xA0); // leaf: uint16 with value 0
+            return [.. bytes];
+        }
+
+        [Fact]
+        public static void TestPointerFanOutIsBounded()
+        {
+            // A data section of nested arrays, each holding two pointers to the
+            // node below, would cost 2**depth decode operations. The decoder
+            // bounds the number of values it decodes per lookup and rejects the
+            // database.
+            const int depth = 100;
+            var bytes = new List<byte> { 0xA0 }; // leaf: uint16 with value 0
+            var prev = 0;
+            for (var i = 0; i < depth; i++)
+            {
+                var offset = bytes.Count;
+                bytes.Add(0x02);
+                bytes.Add(0x04);
+                WritePointer1(bytes, prev);
+                WritePointer1(bytes, prev);
+                prev = offset;
+            }
+
+            using var database = new MemoryMapBuffer(new MemoryStream(bytes.ToArray(), writable: false));
+            var decoder = new Decoder(database, 0);
+            var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(prev, out _));
+            Assert.Contains("maximum number of values", ex.Message);
+        }
+
+        [Fact]
+        public static void TestMapPointerFanOutIsBounded()
+        {
+            // Each map has two distinct keys whose values point to the map
+            // below. Re-decoding the shared targets must consume the map's two
+            // key/value pairs from the value budget on every visit.
+            const int depth = 100;
+            var bytes = new List<byte> { 0xA0 }; // leaf: uint16 with value 0
+            var prev = 0;
+            for (var i = 0; i < depth; i++)
+            {
+                var offset = bytes.Count;
+                bytes.Add(0xE2);
+                bytes.Add(0x41);
+                bytes.Add((byte)'a');
+                WritePointer1(bytes, prev);
+                bytes.Add(0x41);
+                bytes.Add((byte)'b');
+                WritePointer1(bytes, prev);
+                prev = offset;
+            }
+
+            using var database = new MemoryMapBuffer(new MemoryStream(bytes.ToArray(), writable: false));
+            var decoder = new Decoder(database, 0);
+            var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(prev, out _));
+            Assert.Contains("maximum number of values", ex.Message);
+        }
+
+        [Theory]
+        [InlineData(32_768, false)]
+        [InlineData(32_769, true)]
+        public static void TestFlatScalarPointerTargetsConsumeValueBudget(int pointerCount, bool exceedsLimit)
+        {
+            // The array charges each pointer field, and following each pointer
+            // charges its scalar target. At 32,768 pointers the two charges use
+            // the full 65,536-value budget. One more must be rejected. This is
+            // intentionally flat so neither depth nor exponential fan-out can
+            // hide incorrect target accounting.
+            var encodedSize = pointerCount - 285;
+            var bytes = new List<byte>(pointerCount * 2 + 5)
+            {
+                0x40, // target: empty UTF-8 string
+                0x1E, 0x04, // array with a two-byte encoded size
+                (byte)(encodedSize >> 8), (byte)encodedSize,
+            };
+            for (var i = 0; i < pointerCount; i++)
+            {
+                WritePointer1(bytes, 0);
+            }
+
+            using var database = new MemoryMapBuffer(new MemoryStream(bytes.ToArray(), writable: false));
+            var decoder = new Decoder(database, 0);
+            if (exceedsLimit)
+            {
+                var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(1, out _));
+                Assert.Equal(
+                    "The MaxMind DB file's data section exceeds the maximum number of values.",
+                    ex.Message);
+            }
+            else
+            {
+                var decoded = Assert.IsType<List<object>>(decoder.Decode<object>(1, out var offset));
+                Assert.Equal(pointerCount, decoded.Count);
+                Assert.Equal(bytes.Count, offset);
+            }
+        }
+
+        [Theory]
+        [InlineData(21_845, false)]
+        [InlineData(21_846, true)]
+        public static void TestFlatModelKeyPointerTargetsConsumeValueBudget(int pointerCount, bool exceedsLimit)
+        {
+            // A map charges its key and value fields, and following each key
+            // pointer charges the UTF-8 target that DecodeKey hashes. At 21,845
+            // entries those charges use 65,535 values. One more entry crosses
+            // the limit. Empty keys are unknown to KeyOnlyModel, so their false
+            // values are skipped without introducing another pointer path.
+            var encodedSize = pointerCount - 285;
+            var bytes = new List<byte>(pointerCount * 4 + 4)
+            {
+                0x40, // target: empty UTF-8 string
+                0xFE, // map with a two-byte encoded size
+                (byte)(encodedSize >> 8), (byte)encodedSize,
+            };
+            for (var i = 0; i < pointerCount; i++)
+            {
+                WritePointer1(bytes, 0);
+                bytes.Add(0x00); // extended boolean
+                bytes.Add(0x07); // false
+            }
+
+            using var database = new MemoryMapBuffer(new MemoryStream(bytes.ToArray(), writable: false));
+            var decoder = new Decoder(database, 0);
+            if (exceedsLimit)
+            {
+                var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<KeyOnlyModel>(1, out _));
+                Assert.Equal(
+                    "The MaxMind DB file's data section exceeds the maximum number of values.",
+                    ex.Message);
+            }
+            else
+            {
+                var decoded = decoder.Decode<KeyOnlyModel>(1, out var offset);
+                Assert.Null(decoded.Name);
+                Assert.Equal(bytes.Count, offset);
+            }
+        }
+
+        [Theory]
+        [InlineData(32, false)]
+        [InlineData(33, false)]
+        [InlineData(514, true)]
+        public static void TestContainerDepthIsBounded(int containerCount, bool exceedsLimit)
+        {
+            // Exercise alternating maps and arrays on both sides of the
+            // runtime stack-probe threshold.
+            var bytes = NestedContainers(containerCount);
+            using var database = new MemoryMapBuffer(new MemoryStream(bytes, writable: false));
+            var decoder = new Decoder(database, 0);
+
+            if (exceedsLimit)
+            {
+                var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(0, out _));
+                Assert.Equal("The MaxMind DB file's data section exceeds the maximum depth.", ex.Message);
+            }
+            else
+            {
+                decoder.Decode<object>(0, out var offset);
+                Assert.Equal(bytes.Length, offset);
+            }
+        }
+
+        [Fact]
+        public static void TestCyclicPointerThrows()
+        {
+            // A pointer to itself must throw a catchable InvalidDatabaseException
+            // rather than recursing until the stack overflows.
+            using var database = new MemoryMapBuffer(new MemoryStream([0x20, 0x00], writable: false));
+            var decoder = new Decoder(database, 0);
+            Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(0, out _));
+        }
+
+        private sealed class KeyOnlyModel
+        {
+            [Constructor]
+            public KeyOnlyModel([MapKey("name")] string? name = null) => Name = name;
+
+            public string? Name { get; }
+        }
+
+        [Fact]
+        public static void TestOversizedMapIsBounded()
+        {
+            // Declare 32,769 map entries without a body. Charging both keys
+            // and values must exceed the budget before the first read.
+            using var database = new MemoryMapBuffer(new MemoryStream([0xfe, 0x7e, 0xe4], writable: false));
+            var decoder = new Decoder(database, 0);
+            var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(0, out _));
+            Assert.Contains("maximum number of values", ex.Message);
+        }
+
+        [Fact]
+        public static void TestUnknownFieldValueCountIsBounded()
+        {
+            // The root map already charges its key and value. The unknown value
+            // is a complete array whose 65,535 children exceed the remaining
+            // budget. Skipping it must enforce the same limit as decoding it.
+            const int childCount = 65_535;
+            var bytes = new List<byte>(childCount * 2 + 16)
+            {
+                0xE1,
+                0x47,
+                (byte)'u', (byte)'n', (byte)'k', (byte)'n', (byte)'o', (byte)'w', (byte)'n',
+                0x1E, 0x04, 0xFE, 0xE2,
+            };
+            for (var i = 0; i < childCount; i++)
+            {
+                bytes.Add(0x00); // extended boolean with value false
+                bytes.Add(0x07);
+            }
+
+            using var database = new MemoryMapBuffer(new MemoryStream(bytes.ToArray(), writable: false));
+            var decoder = new Decoder(database, 0);
+            var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<KeyOnlyModel>(0, out _));
+            Assert.Contains("maximum number of values", ex.Message);
+        }
+
+        [Fact]
+        public static void TestUnknownFieldDepthIsBounded()
+        {
+            // The unknown map value begins at depth one. Its 513th nested
+            // container therefore exceeds the maximum depth while being
+            // skipped, without any pointers in the data.
+            var nested = NestedContainers(513);
+            var bytes = new List<byte>(nested.Length + 9)
+            {
+                0xE1,
+                0x47,
+                (byte)'u', (byte)'n', (byte)'k', (byte)'n', (byte)'o', (byte)'w', (byte)'n',
+            };
+            bytes.AddRange(nested);
+
+            using var database = new MemoryMapBuffer(new MemoryStream(bytes.ToArray(), writable: false));
+            var decoder = new Decoder(database, 0);
+            var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<KeyOnlyModel>(0, out _));
+            Assert.Contains("maximum depth", ex.Message);
+        }
+
+        [Fact]
+        public static void TestCyclicPointerAsMapKeyThrows()
+        {
+            // Decoding into a model type reads map keys through a separate path
+            // (DecodeKey) from the dictionary path. A key that is a pointer to
+            // itself must also throw a catchable InvalidDatabaseException rather
+            // than overflowing the stack.
+            // 0xe1: map with one entry. The key at offset 1 is a one-byte
+            // pointer (0x20 0x01) whose target is offset 1, the pointer itself.
+            using var database = new MemoryMapBuffer(new MemoryStream([0xe1, 0x20, 0x01], writable: false));
+            var decoder = new Decoder(database, 0);
+            Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<KeyOnlyModel>(0, out _));
+        }
+
         public static IEnumerable<object[]> TestUInt16()
         {
             var uint16s = new Dictionary<object, byte[]>

--- a/MaxMind.Db.Test/DecoderTest.cs
+++ b/MaxMind.Db.Test/DecoderTest.cs
@@ -191,10 +191,9 @@ namespace MaxMind.Db.Test
         }
 
         [Theory]
-        [InlineData(32, false)]
-        [InlineData(33, false)]
-        [InlineData(514, true)]
-        public static void TestContainerDepthIsBounded(int containerCount, bool exceedsLimit)
+        [InlineData(32)]
+        [InlineData(33)]
+        public static void TestContainerDepthAroundStackProbeDecodes(int containerCount)
         {
             // Exercise alternating maps and arrays on both sides of the
             // runtime stack-probe threshold.
@@ -202,16 +201,20 @@ namespace MaxMind.Db.Test
             using var database = new MemoryMapBuffer(new MemoryStream(bytes, writable: false));
             var decoder = new Decoder(database, 0);
 
-            if (exceedsLimit)
-            {
-                var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(0, out _));
-                Assert.Equal("The MaxMind DB file's data section exceeds the maximum depth.", ex.Message);
-            }
-            else
-            {
-                decoder.Decode<object>(0, out var offset);
-                Assert.Equal(bytes.Length, offset);
-            }
+            decoder.Decode<object>(0, out var offset);
+            Assert.Equal(bytes.Length, offset);
+        }
+
+        [Fact]
+        public static void TestContainerDepthBoundaryRejectsOneOverTheLimit()
+        {
+            // One container beyond the depth limit must be rejected.
+            var bytes = NestedContainers(513);
+            using var database = new MemoryMapBuffer(new MemoryStream(bytes, writable: false));
+            var decoder = new Decoder(database, 0);
+
+            var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(0, out _));
+            Assert.Equal("The MaxMind DB file's data section exceeds the maximum depth.", ex.Message);
         }
 
         [Fact]
@@ -459,6 +462,40 @@ namespace MaxMind.Db.Test
             // 2,097,153 - 65,821 = 2,031,332 (0x1efee4).
             using var database = new MemoryMapBuffer(
                 new MemoryStream([0x1f, 0x03, 0x1e, 0xfe, 0xe4], writable: false));
+            var decoder = new Decoder(database, 0);
+            var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(0, out _));
+            Assert.Contains("maximum payload size", ex.Message);
+        }
+
+        [Fact]
+        public static void TestUint32ConsumesPayloadBudget()
+        {
+            // DecodeLong shares ConsumePayload's call pattern with
+            // DecodeBigInteger: it charges the declared length before
+            // ReadLong reads it. This is the same shape as
+            // TestWideIntegerConsumesPayloadBudget, for a uint32 instead of
+            // a uint128. Uint32 (type 6) is a direct type, so no extended
+            // type byte is needed: 0xdf is uint32 with size code 31 (three
+            // size bytes). The size bytes encode the same one-byte-over
+            // length, 2,097,153 - 65,821 = 2,031,332 (0x1efee4).
+            using var database = new MemoryMapBuffer(
+                new MemoryStream([0xdf, 0x1e, 0xfe, 0xe4], writable: false));
+            var decoder = new Decoder(database, 0);
+            var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(0, out _));
+            Assert.Contains("maximum payload size", ex.Message);
+        }
+
+        [Fact]
+        public static void TestUint64ConsumesPayloadBudget()
+        {
+            // Same shape as TestWideIntegerConsumesPayloadBudget, for
+            // DecodeUInt64. 0x1f selects the extended type with size code
+            // 31 (three size bytes). 0x02 is the extended type byte for
+            // uint64 (ObjectType.Uint64 - 7). The size bytes encode the
+            // same one-byte-over length, 2,097,153 - 65,821 = 2,031,332
+            // (0x1efee4).
+            using var database = new MemoryMapBuffer(
+                new MemoryStream([0x1f, 0x02, 0x1e, 0xfe, 0xe4], writable: false));
             var decoder = new Decoder(database, 0);
             var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(0, out _));
             Assert.Contains("maximum payload size", ex.Message);

--- a/MaxMind.Db.Test/DecoderTest.cs
+++ b/MaxMind.Db.Test/DecoderTest.cs
@@ -329,6 +329,26 @@ namespace MaxMind.Db.Test
             Assert.Contains("beyond the end", ex.Message);
         }
 
+        [Fact]
+        public static void TestBufferReadRejectsOutOfBoundsOffsets()
+        {
+            // MemoryMapBuffer's netstandard2.0 read paths and its modern
+            // GetSpan path share one bounds check. This exercises it
+            // directly through Read rather than through the decoder.
+            using var database = new MemoryMapBuffer(new MemoryStream([0x01, 0x02, 0x03, 0x04], writable: false));
+
+            // A read that ends exactly at Length is accepted.
+            Assert.Equal(new byte[] { 0x01, 0x02, 0x03, 0x04 }, database.Read(0, 4));
+
+            // A read that ends one byte past Length is rejected.
+            var pastEnd = Assert.Throws<InvalidDatabaseException>(() => database.Read(0, 5));
+            Assert.Contains("beyond the end", pastEnd.Message);
+
+            // A negative offset is rejected.
+            var negativeOffset = Assert.Throws<InvalidDatabaseException>(() => database.Read(-1, 1));
+            Assert.Contains("beyond the end", negativeOffset.Message);
+        }
+
         public static IEnumerable<object[]> TestUInt16()
         {
             var uint16s = new Dictionary<object, byte[]>

--- a/MaxMind.Db.Test/DecoderTest.cs
+++ b/MaxMind.Db.Test/DecoderTest.cs
@@ -500,6 +500,26 @@ namespace MaxMind.Db.Test
             Assert.Contains("beyond the end", ex.Message);
         }
 
+        [Theory]
+        [InlineData(new byte[] { 0xC4 })]
+        [InlineData(new byte[] { 0x08, 0x02 })]
+        public static void TestTruncatedIntegerThrowsDatabaseException(byte[] bytes)
+        {
+            using var database = new MemoryMapBuffer(new MemoryStream(bytes, writable: false));
+            var decoder = new Decoder(database, 0);
+            var error = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(0, out _));
+            Assert.Contains("beyond the end", error.Message);
+        }
+
+        [Fact]
+        public static void TestTruncatedModelKeyThrowsDatabaseException()
+        {
+            using var database = new MemoryMapBuffer(new MemoryStream([0xE1, 0x44], writable: false));
+            var decoder = new Decoder(database, 0);
+            var error = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<KeyOnlyModel>(0, out _));
+            Assert.Contains("beyond the end", error.Message);
+        }
+
         [Fact]
         public static void TestBufferReadRejectsOutOfBoundsOffsets()
         {

--- a/MaxMind.Db.Test/DecoderTest.cs
+++ b/MaxMind.Db.Test/DecoderTest.cs
@@ -365,6 +365,62 @@ namespace MaxMind.Db.Test
             Assert.Contains("beyond the end", negativeOffset.Message);
         }
 
+        private static byte[] PointerChain(int length)
+        {
+            // Each pointer targets the next two-byte link. The chain ends
+            // in a uint16 zero at offset 2 * length.
+            var bytes = new List<byte>(length * 2 + 1);
+            for (var i = 0; i < length; i++)
+            {
+                WritePointer1(bytes, 2 * (i + 1));
+            }
+            bytes.Add(0xA0); // leaf: uint16 with value 0
+            return [.. bytes];
+        }
+
+        [Theory]
+        [InlineData(511, false)]
+        [InlineData(513, false)]
+        [InlineData(514, true)]
+        public static void TestPointerChainDepthIsBounded(int chainLength, bool exceedsLimit)
+        {
+            // A chain of 513 pointer follows is allowed. The 514th follow
+            // exceeds the depth limit.
+            var bytes = PointerChain(chainLength);
+            using var database = new MemoryMapBuffer(new MemoryStream(bytes, writable: false));
+            var decoder = new Decoder(database, 0);
+
+            if (exceedsLimit)
+            {
+                var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(0, out _));
+                Assert.Equal("The MaxMind DB file's data section exceeds the maximum depth.", ex.Message);
+            }
+            else
+            {
+                Assert.Equal(0, Assert.IsType<int>(decoder.Decode<object>(0, out _)));
+            }
+        }
+
+        [Fact]
+        public static void TestWideIntegerConsumesPayloadBudget()
+        {
+            // DecodeBigInteger calls ConsumePayload before ReadBigInteger
+            // copies the declared bytes into a new array. An oversized
+            // uint128 must be charged against the payload budget before the
+            // copy. This declares a size one byte over the 2 MiB budget with
+            // no body. An early charge reports the payload limit. A late
+            // charge would instead read past the end and report truncation.
+            // 0x1f selects the extended type with size code 31 (three size
+            // bytes). 0x03 is the extended type byte for uint128
+            // (ObjectType.Uint128 - 7). The size bytes encode
+            // 2,097,153 - 65,821 = 2,031,332 (0x1efee4).
+            using var database = new MemoryMapBuffer(
+                new MemoryStream([0x1f, 0x03, 0x1e, 0xfe, 0xe4], writable: false));
+            var decoder = new Decoder(database, 0);
+            var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(0, out _));
+            Assert.Contains("maximum payload size", ex.Message);
+        }
+
         public static IEnumerable<object[]> TestUInt16()
         {
             var uint16s = new Dictionary<object, byte[]>

--- a/MaxMind.Db.Test/DecoderTest.cs
+++ b/MaxMind.Db.Test/DecoderTest.cs
@@ -317,6 +317,18 @@ namespace MaxMind.Db.Test
             Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<KeyOnlyModel>(0, out _));
         }
 
+        [Fact]
+        public static void TestTruncatedPayloadThrowsDatabaseException()
+        {
+            // A string header declaring four bytes at the end of the buffer.
+            // Truncated data is malformed input, so it must surface as the
+            // reader's database exception rather than an argument exception.
+            using var database = new MemoryMapBuffer(new MemoryStream([0x44], writable: false));
+            var decoder = new Decoder(database, 0);
+            var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(0, out _));
+            Assert.Contains("beyond the end", ex.Message);
+        }
+
         public static IEnumerable<object[]> TestUInt16()
         {
             var uint16s = new Dictionary<object, byte[]>

--- a/MaxMind.Db.Test/DecoderTest.cs
+++ b/MaxMind.Db.Test/DecoderTest.cs
@@ -279,6 +279,57 @@ namespace MaxMind.Db.Test
         }
 
         [Fact]
+        public static void TestContainerDepthAtLimitSucceedsGivenSufficientStack()
+        {
+            // Give the thread enough stack to verify that exactly 512
+            // container levels decode.
+            var bytes = NestedContainers(512);
+            Exception? failure = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    using var database = new MemoryMapBuffer(new MemoryStream(bytes, writable: false));
+                    var decoder = new Decoder(database, 0);
+                    decoder.Decode<object>(0, out var offset);
+                    Assert.Equal(bytes.Length, offset);
+                }
+                catch (Exception ex)
+                {
+                    failure = ex;
+                }
+            }, maxStackSize: 16 << 20);
+            thread.Start();
+            thread.Join();
+
+            if (failure != null)
+            {
+                ExceptionDispatchInfo.Capture(failure).Throw();
+            }
+        }
+
+        [Fact]
+        public static void TestContainerDepthAtLimitDoesNotCrashTheHostOnADefaultStack()
+        {
+            // A default stack may be too small for 512 levels. Require success
+            // or a catchable depth error, rather than host termination.
+            var bytes = NestedContainers(512);
+            using var database = new MemoryMapBuffer(new MemoryStream(bytes, writable: false));
+            var decoder = new Decoder(database, 0);
+
+            try
+            {
+                decoder.Decode<object>(0, out var offset);
+                Assert.Equal(bytes.Length, offset);
+            }
+            catch (InvalidDatabaseException ex)
+            {
+                Assert.Equal("The MaxMind DB file's data section exceeds the maximum depth.", ex.Message);
+            }
+        }
+
+        [Fact]
         public static void TestCyclicPointerThrows()
         {
             // A pointer cycle has no container charges. The depth guard

--- a/MaxMind.Db.Test/DecoderTest.cs
+++ b/MaxMind.Db.Test/DecoderTest.cs
@@ -300,6 +300,41 @@ namespace MaxMind.Db.Test
             Assert.Contains("maximum depth", ex.Message);
         }
 
+        // These headers declare oversized values without a body. Expect
+        // a limit error, proving rejection occurs before a payload read.
+
+        [Fact]
+        public static void TestOversizedArrayIsRejectedBeforeFirstChild()
+        {
+            // Declare 65,536 children, one more than the root leaves available.
+            using var database = new MemoryMapBuffer(new MemoryStream([0x1e, 0x04, 0xfe, 0xe3], writable: false));
+            var decoder = new Decoder(database, 0);
+            var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(0, out _));
+            Assert.Contains("maximum number of values", ex.Message);
+        }
+
+        [Fact]
+        public static void TestOversizedStringIsRejectedBeforeItIsRead()
+        {
+            // Declare 2 MiB + 1 string bytes without a payload.
+            using var database = new MemoryMapBuffer(
+                new MemoryStream([0x5f, 0x1e, 0xfe, 0xe4], writable: false));
+            var decoder = new Decoder(database, 0);
+            var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(0, out _));
+            Assert.Contains("maximum payload size", ex.Message);
+        }
+
+        [Fact]
+        public static void TestOversizedBytesIsRejectedBeforeItIsRead()
+        {
+            // Declare 2 MiB + 1 bytes without a payload.
+            using var database = new MemoryMapBuffer(
+                new MemoryStream([0x9f, 0x1e, 0xfe, 0xe4], writable: false));
+            var decoder = new Decoder(database, 0);
+            var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(0, out _));
+            Assert.Contains("maximum payload size", ex.Message);
+        }
+
         [Fact]
         public static void TestTruncatedPayloadThrowsDatabaseException()
         {
@@ -315,9 +350,7 @@ namespace MaxMind.Db.Test
         [Fact]
         public static void TestBufferReadRejectsOutOfBoundsOffsets()
         {
-            // MemoryMapBuffer's netstandard2.0 read paths and its modern
-            // GetSpan path share one bounds check. This exercises it
-            // directly through Read rather than through the decoder.
+            // Exercise the shared bounds check through the buffer API.
             using var database = new MemoryMapBuffer(new MemoryStream([0x01, 0x02, 0x03, 0x04], writable: false));
 
             // A read that ends exactly at Length is accepted.

--- a/MaxMind.Db.Test/DecoderTest.cs
+++ b/MaxMind.Db.Test/DecoderTest.cs
@@ -199,9 +199,8 @@ namespace MaxMind.Db.Test
 
         // The root and 65,535 booleans use the entire value budget
         // without consuming payload bytes.
-        private static byte[] AtValueBudgetLimitArray()
+        private static byte[] ValueBudgetArray(int childCount = 65_535)
         {
-            const int childCount = 65_535;
             var encodedSize = childCount - 285;
             var bytes = new List<byte>(childCount * 2 + 4)
             {
@@ -220,33 +219,49 @@ namespace MaxMind.Db.Test
         }
 
         [Fact]
-        public static void TestManySimultaneousAtBudgetLimitDecodesSucceed()
+        public static void TestConcurrentSuccessfulAndRejectedLookupsHaveSeparateBudgets()
         {
             // Exercise both budgets through one shared decoder. The repeated
             // lookup tests check budget reset without relying on thread overlap.
             const int pointerCount = 8_192;
             const int childCount = 65_535;
             var payloadBytes = FlatScalarPointerTargets(pointerCount, out var arrayOffset);
-            var valueBytes = AtValueBudgetLimitArray();
+            var valueBytes = ValueBudgetArray();
             var valueOffset = payloadBytes.Length;
-            var bytes = new byte[payloadBytes.Length + valueBytes.Length];
+            var excessiveValues = ValueBudgetArray(childCount + 1);
+            var excessiveValueOffset = payloadBytes.Length + valueBytes.Length;
+            var excessivePayload = FlatScalarPointerTargets(pointerCount + 1, out var excessiveArrayOffset);
+            var excessivePayloadOffset = excessiveValueOffset + excessiveValues.Length;
+            var bytes = new byte[excessivePayloadOffset + excessivePayload.Length];
             payloadBytes.CopyTo(bytes, 0);
             valueBytes.CopyTo(bytes, valueOffset);
+            excessiveValues.CopyTo(bytes, excessiveValueOffset);
+            excessivePayload.CopyTo(bytes, excessivePayloadOffset);
 
             using var database = new MemoryMapBuffer(new MemoryStream(bytes, writable: false));
             var decoder = new Decoder(database, 0);
 
             System.Threading.Tasks.Parallel.For(0, 16, i =>
             {
-                if (i % 2 == 0)
+                if (i % 4 == 0)
                 {
                     var decoded = Assert.IsType<List<object>>(decoder.Decode<object>(arrayOffset, out _));
                     Assert.Equal(pointerCount, decoded.Count);
                 }
-                else
+                else if (i % 4 == 1)
                 {
                     var decoded = Assert.IsType<List<object>>(decoder.Decode<object>(valueOffset, out _));
                     Assert.Equal(childCount, decoded.Count);
+                }
+                else if (i % 4 == 2)
+                {
+                    var error = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(excessiveValueOffset, out _));
+                    Assert.Contains("maximum number of values", error.Message);
+                }
+                else
+                {
+                    var error = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(excessivePayloadOffset + excessiveArrayOffset, out _));
+                    Assert.Contains("maximum payload size", error.Message);
                 }
             });
         }
@@ -356,6 +371,38 @@ namespace MaxMind.Db.Test
             var decoder = new Decoder(database, 0);
             var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(0, out _));
             Assert.Contains("maximum number of values", ex.Message);
+        }
+
+        [Theory]
+        [InlineData(32_767, false)]
+        [InlineData(32_768, true)]
+        public static void TestMapValueBudgetBoundary(int entryCount, bool exceedsLimit)
+        {
+            var size = entryCount - 285;
+            var bytes = new List<byte> { 0xFE, (byte)(size >> 8), (byte)size };
+            if (!exceedsLimit)
+            {
+                for (var i = 0; i < entryCount; i++)
+                {
+                    bytes.Add(0x44);
+                    bytes.AddRange(Encoding.ASCII.GetBytes(i.ToString("X4", System.Globalization.CultureInfo.InvariantCulture)));
+                    bytes.AddRange([0x00, 0x07]); // false
+                }
+            }
+            using var database = new MemoryMapBuffer(new MemoryStream(bytes.ToArray(), writable: false));
+            var decoder = new Decoder(database, 0);
+            if (exceedsLimit)
+            {
+                var error = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(0, out _));
+                Assert.Contains("maximum number of values", error.Message);
+            }
+            else
+            {
+                var record = decoder.Decode<Dictionary<string, object>>(0, out var offset);
+                Assert.Equal(entryCount, record.Count);
+                Assert.False(Assert.IsType<bool>(record["7FFE"]));
+                Assert.Equal(bytes.Count, offset);
+            }
         }
 
         [Fact]

--- a/MaxMind.Db.Test/DecoderTest.cs
+++ b/MaxMind.Db.Test/DecoderTest.cs
@@ -559,6 +559,44 @@ namespace MaxMind.Db.Test
             }
         }
 
+        // Each array slot follows the shared chain again. This exercises many
+        // pointer follows within the depth and value limits, without a timing assertion.
+        private static byte[] ManySlotsEachFollowingALongPointerChain(int slotCount, int chainLength, out int arrayOffset)
+        {
+            var chain = PointerChain(chainLength);
+            var bytes = new List<byte>(chain.Length + slotCount * 2 + 8);
+            bytes.AddRange(chain);
+            arrayOffset = bytes.Count;
+            var encodedSize = slotCount - 285;
+            bytes.Add(0x1E); // array with a two-byte encoded size
+            bytes.Add(0x04);
+            bytes.Add((byte)(encodedSize >> 8));
+            bytes.Add((byte)encodedSize);
+            for (var i = 0; i < slotCount; i++)
+            {
+                WritePointer1(bytes, 0);
+            }
+
+            return [.. bytes];
+        }
+
+        [Fact]
+        public static void TestManySlotsEachFollowingALongPointerChainTerminates()
+        {
+            // Each slot adds one pointer before the 300-link chain: 301,000
+            // follows in total. The root and slots cost 1,001 values, and the
+            // leaf is reached at depth 302, within both limits.
+            const int slotCount = 1_000;
+            const int chainLength = 300;
+            var bytes = ManySlotsEachFollowingALongPointerChain(slotCount, chainLength, out var arrayOffset);
+            using var database = new MemoryMapBuffer(new MemoryStream(bytes, writable: false));
+            var decoder = new Decoder(database, 0);
+
+            var decoded = Assert.IsType<List<object>>(decoder.Decode<object>(arrayOffset, out var offset));
+            Assert.Equal(slotCount, decoded.Count);
+            Assert.Equal(bytes.Length, offset);
+        }
+
         [Fact]
         public static void TestWideIntegerConsumesPayloadBudget()
         {

--- a/MaxMind.Db.Test/DecoderTest.cs
+++ b/MaxMind.Db.Test/DecoderTest.cs
@@ -406,6 +406,43 @@ namespace MaxMind.Db.Test
             Assert.Contains("maximum depth", ex.Message);
         }
 
+        [Theory]
+        [InlineData(1, false)]
+        [InlineData(2, false)]
+        [InlineData(511, false)]
+        [InlineData(512, true)]
+        public static void TestMapKeyPointerChainPreservesValueOffset(int pointerCount, bool exceedsLimit)
+        {
+            // Place the pointer targets before the map so that its following
+            // value is only found by retaining the first pointer's end offset.
+            var bytes = new List<byte> { 0x44, (byte)'n', (byte)'a', (byte)'m', (byte)'e' };
+            var target = 0;
+            for (var i = 1; i < pointerCount; i++)
+            {
+                var pointerOffset = bytes.Count;
+                WritePointer1(bytes, target);
+                target = pointerOffset;
+            }
+            var mapOffset = bytes.Count;
+            bytes.Add(0xE1);
+            WritePointer1(bytes, target);
+            bytes.AddRange([0x43, (byte)'v', (byte)'a', (byte)'l']);
+
+            using var database = new MemoryMapBuffer(new MemoryStream(bytes.ToArray(), writable: false));
+            var decoder = new Decoder(database, 0);
+            if (exceedsLimit)
+            {
+                var error = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<KeyOnlyModel>(mapOffset, out _));
+                Assert.Contains("maximum depth", error.Message);
+            }
+            else
+            {
+                var record = decoder.Decode<KeyOnlyModel>(mapOffset, out var offset);
+                Assert.Equal("val", record.Name);
+                Assert.Equal(bytes.Count, offset);
+            }
+        }
+
         [Fact]
         public static void TestCyclicPointerAsMapKeyThrows()
         {

--- a/MaxMind.Db.Test/DecoderTest.cs
+++ b/MaxMind.Db.Test/DecoderTest.cs
@@ -4,7 +4,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Numerics;
+using System.Runtime.ExceptionServices;
 using System.Text;
+using System.Threading;
 using Xunit;
 
 #endregion
@@ -271,7 +273,7 @@ namespace MaxMind.Db.Test
         [Fact]
         public static void TestUnknownFieldDepthIsBounded()
         {
-            // The unknown map value begins at depth one. Its 513th nested
+            // The unknown map value begins at depth one. Its 512th nested
             // container therefore exceeds the maximum depth while being
             // skipped, without any pointers in the data.
             var nested = NestedContainers(513);
@@ -380,11 +382,11 @@ namespace MaxMind.Db.Test
 
         [Theory]
         [InlineData(511, false)]
-        [InlineData(513, false)]
-        [InlineData(514, true)]
+        [InlineData(512, false)]
+        [InlineData(513, true)]
         public static void TestPointerChainDepthIsBounded(int chainLength, bool exceedsLimit)
         {
-            // A chain of 513 pointer follows is allowed. The 514th follow
+            // A chain of 512 pointer follows is allowed. The 513th follow
             // exceeds the depth limit.
             var bytes = PointerChain(chainLength);
             using var database = new MemoryMapBuffer(new MemoryStream(bytes, writable: false));
@@ -398,6 +400,47 @@ namespace MaxMind.Db.Test
             else
             {
                 Assert.Equal(0, Assert.IsType<int>(decoder.Decode<object>(0, out _)));
+            }
+        }
+
+        [Fact]
+        public static void TestDepthAccumulatesAcrossContainerIntoPointerChain()
+        {
+            // The array element adds one pointer to a 511-link chain.
+            // Those 512 follows succeed at root depth but exceed the limit
+            // when the array contributes one level. Give the thread enough
+            // stack to test the depth limit without a runtime stack rejection.
+            var chain = PointerChain(511);
+            var arrayOffset = chain.Length;
+            var bytes = new List<byte>(chain.Length + 4);
+            bytes.AddRange(chain);
+            bytes.Add(0x01); // extended type, size 1
+            bytes.Add(0x04); // extended type byte: array (11 - 7)
+            var pointerOffset = bytes.Count;
+            WritePointer1(bytes, 0);
+            Exception? failure = null;
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    using var database = new MemoryMapBuffer(new MemoryStream(bytes.ToArray(), writable: false));
+                    var decoder = new Decoder(database, 0);
+                    Assert.Equal(0, Assert.IsType<int>(decoder.Decode<object>(pointerOffset, out _)));
+                    var ex = Assert.Throws<InvalidDatabaseException>(() => decoder.Decode<object>(arrayOffset, out _));
+                    Assert.Equal("The MaxMind DB file's data section exceeds the maximum depth.", ex.Message);
+                }
+                catch (Exception ex)
+                {
+                    failure = ex;
+                }
+            }, maxStackSize: 16 << 20);
+            thread.Start();
+            thread.Join();
+
+            if (failure != null)
+            {
+                ExceptionDispatchInfo.Capture(failure).Throw();
             }
         }
 

--- a/MaxMind.Db.Test/MemoryMapBufferTest.cs
+++ b/MaxMind.Db.Test/MemoryMapBufferTest.cs
@@ -1,0 +1,39 @@
+using System.IO;
+using Xunit;
+
+namespace MaxMind.Db.Test
+{
+    public static class MemoryMapBufferTest
+    {
+        [Theory]
+        [InlineData(0, 5)]
+        [InlineData(3, 2)]
+        [InlineData(-1, 1)]
+        [InlineData(long.MaxValue, 1)]
+        public static void ReadsRejectOutOfBoundsRanges(long offset, int count)
+        {
+            using var buffer = new MemoryMapBuffer(new MemoryStream(new byte[4], writable: false));
+            using var other = new MemoryMapBuffer(new MemoryStream(new byte[8], writable: false));
+            Assert.Throws<InvalidDatabaseException>(() => buffer.HashBytes(offset, count));
+            Assert.Throws<InvalidDatabaseException>(() => buffer.ReadLong(offset, count));
+            Assert.Throws<InvalidDatabaseException>(() => buffer.ReadULong(offset, count));
+            Assert.Throws<InvalidDatabaseException>(() => buffer.EqualsBytes(offset, new byte[8], 0, count));
+            // Both operands must be checked, even when all bytes compare equal.
+            Assert.Throws<InvalidDatabaseException>(() => buffer.EqualsBytes(offset, other, 0, count));
+            Assert.Throws<InvalidDatabaseException>(() => other.EqualsBytes(0, buffer, offset, count));
+        }
+
+        [Fact]
+        public static void ReadsAcceptRangesEndingAtTheBufferBoundary()
+        {
+            using var buffer = new MemoryMapBuffer(new MemoryStream([0, 1, 2, 3], writable: false));
+            using var other = new MemoryMapBuffer(new MemoryStream([1, 2, 3], writable: false));
+            Assert.Equal(0x010203, buffer.ReadLong(1, 3));
+            Assert.Equal(0x010203UL, buffer.ReadULong(1, 3));
+            Assert.Equal(other.HashBytes(0, 3), buffer.HashBytes(1, 3));
+            Assert.True(buffer.EqualsBytes(1, other, 0, 3));
+            Assert.True(buffer.EqualsBytes(1, new byte[] { 1, 2, 3 }, 0, 3));
+            Assert.False(buffer.EqualsBytes(1, new byte[] { 1, 2, 4 }, 0, 3));
+        }
+    }
+}

--- a/MaxMind.Db.Test/ReaderTest.cs
+++ b/MaxMind.Db.Test/ReaderTest.cs
@@ -773,6 +773,55 @@ namespace MaxMind.Db.Test
             Assert.NotNull(reader.Find<object>(IPAddress.Parse("1.1.1.1")));
         }
 
+        // Exercise the memory-loading path with the same hostile fixture.
+        [Fact]
+        public void TestPayloadLimitAppliesToMemoryMode()
+        {
+            var path = Path.Combine(_testDataRoot, "MaxMind-DB-test-payload-amplification-dos.mmdb");
+            using var reader = new Reader(path, FileAccessMode.Memory);
+            var ex = Assert.Throws<InvalidDatabaseException>(
+                () => reader.Find<object>(IPAddress.Parse("1.1.1.1")));
+            Assert.Contains("maximum payload size", ex.Message);
+        }
+
+        [Fact]
+        public void TestPayloadLimitAppliesToStreamConstruction()
+        {
+            var path = Path.Combine(_testDataRoot, "MaxMind-DB-test-payload-amplification-dos.mmdb");
+            using var stream = File.OpenRead(path);
+            using var reader = new Reader(stream);
+            var ex = Assert.Throws<InvalidDatabaseException>(
+                () => reader.Find<object>(IPAddress.Parse("1.1.1.1")));
+            Assert.Contains("maximum payload size", ex.Message);
+        }
+
+        [Fact]
+        public async Task TestPayloadLimitAppliesToAsyncConstruction()
+        {
+            var path = Path.Combine(_testDataRoot, "MaxMind-DB-test-payload-amplification-dos.mmdb");
+            using var reader = await Reader.CreateAsync(path);
+            var ex = Assert.Throws<InvalidDatabaseException>(
+                () => reader.Find<object>(IPAddress.Parse("1.1.1.1")));
+            Assert.Contains("maximum payload size", ex.Message);
+        }
+
+        [Fact]
+        public void TestPayloadLimitAppliesToFindAll()
+        {
+            // Enumeration must reject the hostile record when it is decoded.
+            var path = Path.Combine(_testDataRoot, "MaxMind-DB-test-payload-amplification-dos.mmdb");
+            using var reader = new Reader(path);
+            var ex = Assert.Throws<InvalidDatabaseException>(
+                () =>
+                {
+                    foreach (var node in reader.FindAll<object>())
+                    {
+                        _ = node;
+                    }
+                });
+            Assert.Contains("maximum payload size", ex.Message);
+        }
+
         private static void TestMetadata(Reader reader, int ipVersion)
         {
             var metadata = reader.Metadata;

--- a/MaxMind.Db.Test/ReaderTest.cs
+++ b/MaxMind.Db.Test/ReaderTest.cs
@@ -748,7 +748,11 @@ namespace MaxMind.Db.Test
             // Exactly 65,536 decoded values, the boundary the limit allows.
             using var reader = new Reader(
                 Path.Combine(_testDataRoot, "MaxMind-DB-test-decoder-value-limit.mmdb"));
-            Assert.NotNull(reader.Find<object>(IPAddress.Parse("1.1.1.1")));
+            for (var i = 0; i < 3; i++)
+            {
+                var values = Assert.IsType<List<object>>(reader.Find<object>(IPAddress.Parse("1.1.1.1")));
+                Assert.Equal(65_535, values.Count);
+            }
         }
 
         [Fact]

--- a/MaxMind.Db.Test/ReaderTest.cs
+++ b/MaxMind.Db.Test/ReaderTest.cs
@@ -826,6 +826,51 @@ namespace MaxMind.Db.Test
             Assert.Contains("maximum payload size", ex.Message);
         }
 
+        [Theory]
+        [InlineData(FileAccessMode.MemoryMapped)]
+        [InlineData(FileAccessMode.Memory)]
+        public void TestTruncatedRecordThrowsDatabaseException(FileAccessMode mode)
+        {
+            // The string declares 4,096 bytes, extending past the metadata and
+            // the end of this small database. Its header is inside the file.
+            var bytes = DatabaseWithRootRecords([0x5E, 0x0E, 0xE3], [0xA0]);
+            var path = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllBytes(path, bytes);
+                using var reader = new Reader(path, mode);
+                var error = Assert.Throws<InvalidDatabaseException>(() => reader.Find<object>(IPAddress.Parse("1.1.1.1")));
+                Assert.Contains("beyond the end", error.Message);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        private byte[] DatabaseWithRootRecords(byte[] left, byte[] right)
+        {
+            var path = Path.Combine(_testDataRoot, "MaxMind-DB-test-ipv4-24.mmdb");
+            using var source = new Reader(path);
+            var original = File.ReadAllBytes(path);
+            byte[] marker = [0xAB, 0xCD, 0xEF, (byte)'M', (byte)'a', (byte)'x', (byte)'M', (byte)'i', (byte)'n', (byte)'d', (byte)'.', (byte)'c', (byte)'o', (byte)'m'];
+            var metadataOffset = Enumerable.Range(0, original.Length - marker.Length + 1)
+                .Last(i => original.Skip(i).Take(marker.Length).SequenceEqual(marker));
+            var bytes = new List<byte>(original.Take(metadataOffset));
+            var leftPointer = bytes.Count - source.Metadata.SearchTreeSize + source.Metadata.NodeCount;
+            bytes.AddRange(left);
+            var rightPointer = bytes.Count - source.Metadata.SearchTreeSize + source.Metadata.NodeCount;
+            bytes.AddRange(right);
+            bytes.AddRange(original.Skip(metadataOffset));
+            // Root children select the two records by the address's first bit.
+            for (var i = 0; i < 3; i++)
+            {
+                bytes[i] = (byte)(leftPointer >> (16 - 8 * i));
+                bytes[i + 3] = (byte)(rightPointer >> (16 - 8 * i));
+            }
+            return [.. bytes];
+        }
+
         private static void TestMetadata(Reader reader, int ipVersion)
         {
             var metadata = reader.Metadata;

--- a/MaxMind.Db.Test/ReaderTest.cs
+++ b/MaxMind.Db.Test/ReaderTest.cs
@@ -681,6 +681,53 @@ namespace MaxMind.Db.Test
             }
         }
 
+        // Repeated pointers to one large scalar must exhaust the payload
+        // budget even when the value count is within its limit.
+        [Theory]
+        [InlineData("MaxMind-DB-test-payload-amplification-dos.mmdb", "maximum payload size")]
+        [InlineData("MaxMind-DB-test-payload-amplification-dos-string.mmdb", "maximum payload size")]
+        // Charging pointer targets separately exhausts the value budget first.
+        [InlineData("MaxMind-DB-test-payload-amplification-dos-worst-case.mmdb", "maximum number of values")]
+        public void TestPayloadAmplificationIsRejected(string fixture, string expected)
+        {
+            using var reader = new Reader(Path.Combine(_testDataRoot, fixture));
+            var ex = Assert.Throws<InvalidDatabaseException>(
+                () => reader.Find<object>(IPAddress.Parse("1.1.1.1")));
+            Assert.Contains(expected, ex.Message);
+        }
+
+        [Fact]
+        public void TestPayloadAtLimitDecodes()
+        {
+            // Exactly 2 MiB of bytes payload must decode.
+            using var reader = new Reader(
+                Path.Combine(_testDataRoot, "MaxMind-DB-test-decoder-payload-limit.mmdb"));
+            var result = reader.Find<object>(IPAddress.Parse("1.1.1.1"));
+            var list = Assert.IsType<List<object>>(result);
+            Assert.Equal(33, list.Count);
+        }
+
+        [Fact]
+        public void TestPayloadOverLimitIsRejected()
+        {
+            // One byte over 2 MiB must be rejected.
+            using var reader = new Reader(
+                Path.Combine(_testDataRoot, "MaxMind-DB-test-decoder-payload-limit-over.mmdb"));
+            var ex = Assert.Throws<InvalidDatabaseException>(
+                () => reader.Find<object>(IPAddress.Parse("1.1.1.1")));
+            Assert.Contains("maximum payload size", ex.Message);
+        }
+
+        [Fact]
+        public void TestMetadataPayloadLimitIsRejectedOnOpen()
+        {
+            // The metadata languages array alone exceeds the payload limit.
+            var ex = Assert.Throws<InvalidDatabaseException>(
+                () => new Reader(
+                    Path.Combine(_testDataRoot, "MaxMind-DB-test-metadata-payload-limit.mmdb")));
+            Assert.Contains("maximum payload size", ex.Message);
+        }
+
         private static void TestMetadata(Reader reader, int ipVersion)
         {
             var metadata = reader.Metadata;

--- a/MaxMind.Db.Test/ReaderTest.cs
+++ b/MaxMind.Db.Test/ReaderTest.cs
@@ -848,6 +848,54 @@ namespace MaxMind.Db.Test
             }
         }
 
+        [Theory]
+        [InlineData(FileAccessMode.MemoryMapped)]
+        [InlineData(FileAccessMode.Memory)]
+        public void TestReaderRecoversAfterModelLimitFailure(FileAccessMode mode)
+        {
+            // Populate one constructor argument before the next field exceeds
+            // the value limit. The successful record omits that first field.
+            byte[] hostile = [0xE2, 0x44, (byte)'n', (byte)'a', (byte)'m', (byte)'e',
+                0x43, (byte)'b', (byte)'a', (byte)'d',
+                0x46, (byte)'v', (byte)'a', (byte)'l', (byte)'u', (byte)'e', (byte)'s',
+                0x1E, 0x04, 0xFE, 0xE2];
+            byte[] valid = [0xE1, 0x46, (byte)'v', (byte)'a', (byte)'l', (byte)'u', (byte)'e', (byte)'s',
+                0x01, 0x04, 0x01, 0x07]; // one-element array containing true
+            var path = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllBytes(path, DatabaseWithRootRecords(hostile, valid));
+                using var reader = new Reader(path, mode);
+                for (var i = 0; i < 3; i++)
+                {
+                    var error = Assert.Throws<InvalidDatabaseException>(() => reader.Find<RecoveryRecord>(IPAddress.Parse("1.1.1.1")));
+                    Assert.Contains("maximum number of values", error.Message);
+                    var record = reader.Find<RecoveryRecord>(IPAddress.Parse("129.1.1.1"));
+                    Assert.NotNull(record);
+                    Assert.Null(record.Name);
+                    Assert.NotNull(record.Values);
+                    Assert.True(Assert.IsType<bool>(Assert.Single(record.Values)));
+                }
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        private sealed class RecoveryRecord
+        {
+            [Constructor]
+            public RecoveryRecord(string? name = null, List<object>? values = null)
+            {
+                Name = name;
+                Values = values;
+            }
+
+            public string? Name { get; }
+            public List<object>? Values { get; }
+        }
+
         private byte[] DatabaseWithRootRecords(byte[] left, byte[] right)
         {
             var path = Path.Combine(_testDataRoot, "MaxMind-DB-test-ipv4-24.mmdb");

--- a/MaxMind.Db.Test/ReaderTest.cs
+++ b/MaxMind.Db.Test/ReaderTest.cs
@@ -686,8 +686,9 @@ namespace MaxMind.Db.Test
         [Theory]
         [InlineData("MaxMind-DB-test-payload-amplification-dos.mmdb", "maximum payload size")]
         [InlineData("MaxMind-DB-test-payload-amplification-dos-string.mmdb", "maximum payload size")]
-        // Charging pointer targets separately exhausts the value budget first.
-        [InlineData("MaxMind-DB-test-payload-amplification-dos-worst-case.mmdb", "maximum number of values")]
+        // The value count is exactly at its limit. Each target is 65,535
+        // bytes, so the 33rd occurrence crosses the 2 MiB payload limit.
+        [InlineData("MaxMind-DB-test-payload-amplification-dos-worst-case.mmdb", "maximum payload size")]
         public void TestPayloadAmplificationIsRejected(string fixture, string expected)
         {
             using var reader = new Reader(Path.Combine(_testDataRoot, fixture));
@@ -726,6 +727,50 @@ namespace MaxMind.Db.Test
                 () => new Reader(
                     Path.Combine(_testDataRoot, "MaxMind-DB-test-metadata-payload-limit.mmdb")));
             Assert.Contains("maximum payload size", ex.Message);
+        }
+
+        // The shared array targets must exhaust the value budget through
+        // the real tree walk and pointer base.
+        [Theory]
+        [InlineData("MaxMind-DB-test-pointer-decoder-dos.mmdb", "1.1.1.1")]
+        [InlineData("MaxMind-DB-test-pointer-decoder-dos-ipv6.mmdb", "::1")]
+        public void TestPointerFanOutFixtureIsRejected(string fixture, string address)
+        {
+            using var reader = new Reader(Path.Combine(_testDataRoot, fixture));
+            var ex = Assert.Throws<InvalidDatabaseException>(
+                () => reader.Find<object>(IPAddress.Parse(address)));
+            Assert.Contains("maximum number of values", ex.Message);
+        }
+
+        [Fact]
+        public void TestValueCountAtLimitDecodes()
+        {
+            // Exactly 65,536 decoded values, the boundary the limit allows.
+            using var reader = new Reader(
+                Path.Combine(_testDataRoot, "MaxMind-DB-test-decoder-value-limit.mmdb"));
+            Assert.NotNull(reader.Find<object>(IPAddress.Parse("1.1.1.1")));
+        }
+
+        [Fact]
+        public void TestValueCountOverLimitIsRejected()
+        {
+            // One value past 65,536. Catches an off-by-one in the comparison.
+            using var reader = new Reader(
+                Path.Combine(_testDataRoot, "MaxMind-DB-test-decoder-value-limit-over.mmdb"));
+            var ex = Assert.Throws<InvalidDatabaseException>(
+                () => reader.Find<object>(IPAddress.Parse("1.1.1.1")));
+            Assert.Contains("maximum number of values", ex.Message);
+        }
+
+        [Fact]
+        public void TestPointerHeavyValueCountDecodes()
+        {
+            // 65,535 values reached through a depth-15 pointer fan-out, one
+            // under the limit. A reader that over-counts a followed pointer
+            // would reject this conformant database.
+            using var reader = new Reader(
+                Path.Combine(_testDataRoot, "MaxMind-DB-test-decoder-value-limit-pointer-heavy.mmdb"));
+            Assert.NotNull(reader.Find<object>(IPAddress.Parse("1.1.1.1")));
         }
 
         private static void TestMetadata(Reader reader, int ipVersion)

--- a/MaxMind.Db/Decoder.cs
+++ b/MaxMind.Db/Decoder.cs
@@ -88,7 +88,7 @@ namespace MaxMind.Db
                 return;
             }
 
-            if (depth > MaxDepth || !HasSufficientExecutionStack())
+            if (depth >= MaxDepth || !HasSufficientExecutionStack())
             {
                 throw new InvalidDatabaseException(
                     "The MaxMind DB file's data section exceeds the maximum depth.");

--- a/MaxMind.Db/Decoder.cs
+++ b/MaxMind.Db/Decoder.cs
@@ -646,29 +646,36 @@ namespace MaxMind.Db
         private Key DecodeKey(long offset, out long outOffset, int depth, ref int payloadBudget)
         {
             var type = CtrlData(offset, out var size, out offset);
-            switch (type)
+            if (type == ObjectType.Pointer)
             {
-                case ObjectType.Pointer:
-                    // A key can only be a string, so it cannot fan out, and the
-                    // enclosing map already charged this key against the value
-                    // budget. It can still point at another pointer, so guard
-                    // the depth to stop a pointer cycle from overflowing the
-                    // stack with an uncatchable StackOverflowException.
+                CheckDepth(depth);
+                offset = DecodePointer(offset, size, out outOffset);
+                while (true)
+                {
+                    depth++;
+                    type = CtrlData(offset, out size, out offset);
+                    if (type != ObjectType.Pointer)
+                    {
+                        break;
+                    }
                     CheckDepth(depth);
-                    offset = DecodePointer(offset, size, out outOffset);
-                    return DecodeKey(offset, out _, depth + 1, ref payloadBudget);
-
-                case ObjectType.Utf8String:
-                    // The key is hashed over its bytes now and compared later, so
-                    // a pointer-backed key re-hashes its target on every visit.
-                    // Charge its length so a fan-out of large keys is bounded.
-                    ConsumePayload(size, ref payloadBudget);
-                    outOffset = offset + size;
-                    return new Key(_database, offset, size);
-
-                default:
-                    throw new InvalidDatabaseException($"Database contains a non-string as map key: {type}");
+                    offset = DecodePointer(offset, size, out _);
+                }
             }
+            else
+            {
+                outOffset = offset + size;
+            }
+
+            if (type != ObjectType.Utf8String)
+            {
+                throw new InvalidDatabaseException($"Database contains a non-string as map key: {type}");
+            }
+
+            // Preserve the offset after the first pointer and charge the final
+            // string once, regardless of the number of pointers followed.
+            ConsumePayload(size, ref payloadBudget);
+            return new Key(_database, offset, size);
         }
 
         // The enclosing container charged numberToSkip. Skipped containers

--- a/MaxMind.Db/Decoder.cs
+++ b/MaxMind.Db/Decoder.cs
@@ -212,6 +212,12 @@ namespace MaxMind.Db
 
             // The size calculation is inlined as it is hot code
             size = ctrlByte & 0x1f;
+            // Pointer control bits encode the pointer width and value, not a payload size.
+            if (type == ObjectType.Pointer)
+            {
+                outOffset = offset;
+                return type;
+            }
             if (size >= 29)
             {
                 var bytesToRead = size - 28;

--- a/MaxMind.Db/Decoder.cs
+++ b/MaxMind.Db/Decoder.cs
@@ -51,11 +51,20 @@ namespace MaxMind.Db
         // stack overflows (a StackOverflowException cannot be caught in .NET).
         // The value limit stops a pointer fan-out, where nested pointers to
         // shared targets would otherwise cost 2**depth decode operations. The
-        // running depth and value budget are passed through the decode call, so
-        // a single Decoder stays safe for concurrent lookups with no shared
-        // mutable state. The largest real records decode a few hundred values.
+        // payload limit stops payload amplification, where many pointers to one
+        // large string or bytes value would otherwise materialize N*size bytes
+        // from a small file; each string, bytes, and wide-integer value is
+        // charged by its length wherever it is decoded, so a re-decoded shared
+        // target is recharged. The running depth, value budget, and payload
+        // budget are passed through the decode call, so a single Decoder stays
+        // safe for concurrent lookups with no shared mutable state. The largest
+        // real records decode a few hundred values and a few kilobytes.
         private const int MaxDepth = 512;
         private const int MaxDecodedValues = 1 << 16;
+        // Limit encoded string, bytes, uint32, uint64, and uint128 payload
+        // per lookup. This also rejects single values larger than 2 MiB,
+        // even when their size is permitted by the file format.
+        private const int MaxPayloadBytes = 1 << 21;
         // The runtime stack can run out before the depth limit. Probe only
         // at deeper levels to avoid the cost on shallow records.
         private const int RuntimeStackCheckDepth = 32;
@@ -121,6 +130,19 @@ namespace MaxMind.Db
             }
         }
 
+        // Charge encoded payload before reading it, including each visit
+        // to a shared target and each map key examined.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void ConsumePayload(int size, ref int payloadBudget)
+        {
+            if (size > payloadBudget)
+            {
+                throw new InvalidDatabaseException(
+                    "The MaxMind DB file's data section exceeds the maximum payload size.");
+            }
+            payloadBudget -= size;
+        }
+
         private readonly DictionaryActivatorCreator _dictionaryActivatorCreator;
         private readonly ListActivatorCreator _listActivatorCreator;
 
@@ -151,27 +173,30 @@ namespace MaxMind.Db
         internal T Decode<T>(long offset, out long outOffset, InjectableValues? injectables = null, Network? network = default) where T : class
         {
             // The per-lookup decode limits are threaded as parameters (a value
-            // depth and a shared remaining-value budget) rather than stored on
-            // the shared Decoder, so they add no thread-local access and keep the
-            // decoder safe for concurrent reads.
+            // depth, a shared remaining-value budget, and a shared remaining
+            // payload-byte budget) rather than stored on the shared Decoder, so
+            // they add no thread-local access and keep the decoder safe for
+            // concurrent reads.
             var budget = MaxDecodedValues;
-            return DecodeNested<T>(offset, out outOffset, 0, ref budget, injectables, network);
+            var payloadBudget = MaxPayloadBytes;
+            return DecodeNested<T>(offset, out outOffset, 0, ref budget, ref payloadBudget, injectables, network);
         }
 
-        private T DecodeNested<T>(long offset, out long outOffset, int depth, ref int budget, InjectableValues? injectables, Network? network) where T : class
+        private T DecodeNested<T>(long offset, out long outOffset, int depth, ref int budget, ref int payloadBudget, InjectableValues? injectables, Network? network) where T : class
         {
-            if (Decode(typeof(T), offset, out outOffset, depth, ref budget, injectables, network) is not T decoded)
+            if (Decode(typeof(T), offset, out outOffset, depth, ref budget, ref payloadBudget, injectables, network) is not T decoded)
             {
                 throw new InvalidDatabaseException("The value cannot be decoded as " + typeof(T));
             }
             return decoded;
         }
 
-        private object Decode(Type expectedType, long offset, out long outOffset, int depth, ref int budget, InjectableValues? injectables = null, Network? network = null)
+        private object Decode(Type expectedType, long offset, out long outOffset, int depth, ref int budget, ref int payloadBudget, InjectableValues? injectables = null, Network? network = null)
         {
             // Depth and value checks apply at containers and pointers.
+            // Scalars charge payload where applicable.
             var type = CtrlData(offset, out var size, out offset);
-            return DecodeByType(expectedType, type, offset, size, out outOffset, depth, ref budget, injectables, network);
+            return DecodeByType(expectedType, type, offset, size, out outOffset, depth, ref budget, ref payloadBudget, injectables, network);
         }
 
         private ObjectType CtrlData(long offset, out int size, out long outOffset)
@@ -230,6 +255,7 @@ namespace MaxMind.Db
         /// <param name="outOffset">The out offset</param>
         /// <param name="depth">The current nesting depth.</param>
         /// <param name="budget">The remaining number of values that may be decoded.</param>
+        /// <param name="payloadBudget">The remaining payload budget in bytes.</param>
         /// <param name="injectables"></param>
         /// <param name="network"></param>
         /// <returns></returns>
@@ -242,6 +268,7 @@ namespace MaxMind.Db
             out long outOffset,
             int depth,
             ref int budget,
+            ref int payloadBudget,
             InjectableValues? injectables,
             Network? network
             )
@@ -260,23 +287,23 @@ namespace MaxMind.Db
 
                     CheckDepth(depth);
                     ConsumePointerTarget(ref budget);
-                    return Decode(expectedType, pointer, out _, depth + 1, ref budget, injectables, network);
+                    return Decode(expectedType, pointer, out _, depth + 1, ref budget, ref payloadBudget, injectables, network);
 
                 case ObjectType.Map:
                     // A map entry decodes a key and a value, so it costs two values.
                     CheckContainer(depth, size * 2, ref budget);
-                    return DecodeMap(expectedType, offset, size, out outOffset, depth, ref budget, injectables, network);
+                    return DecodeMap(expectedType, offset, size, out outOffset, depth, ref budget, ref payloadBudget, injectables, network);
 
                 case ObjectType.Array:
                     CheckContainer(depth, size, ref budget);
-                    return DecodeArray(expectedType, size, offset, out outOffset, depth, ref budget, injectables, network);
+                    return DecodeArray(expectedType, size, offset, out outOffset, depth, ref budget, ref payloadBudget, injectables, network);
 
                 case ObjectType.Boolean:
                     outOffset = offset;
                     return DecodeBoolean(expectedType, size);
 
                 case ObjectType.Utf8String:
-                    return DecodeString(expectedType, offset, size);
+                    return DecodeString(expectedType, offset, size, ref payloadBudget);
 
                 case ObjectType.Double:
                     return DecodeDouble(expectedType, offset, size);
@@ -285,22 +312,22 @@ namespace MaxMind.Db
                     return DecodeFloat(expectedType, offset, size);
 
                 case ObjectType.Bytes:
-                    return DecodeBytes(expectedType, offset, size);
+                    return DecodeBytes(expectedType, offset, size, ref payloadBudget);
 
                 case ObjectType.Uint16:
                     return DecodeInteger(expectedType, offset, size);
 
                 case ObjectType.Uint32:
-                    return DecodeLong(expectedType, offset, size);
+                    return DecodeLong(expectedType, offset, size, ref payloadBudget);
 
                 case ObjectType.Int32:
                     return DecodeInteger(expectedType, offset, size);
 
                 case ObjectType.Uint64:
-                    return DecodeUInt64(expectedType, offset, size);
+                    return DecodeUInt64(expectedType, offset, size, ref payloadBudget);
 
                 case ObjectType.Uint128:
-                    return DecodeBigInteger(expectedType, offset, size);
+                    return DecodeBigInteger(expectedType, offset, size, ref payloadBudget);
 
                 default:
                     throw new InvalidDatabaseException("Unable to handle type: " + type);
@@ -373,17 +400,19 @@ namespace MaxMind.Db
         ///     Decodes the string.
         /// </summary>
         /// <returns></returns>
-        private string DecodeString(Type expectedType, long offset, int size)
+        private string DecodeString(Type expectedType, long offset, int size, ref int payloadBudget)
         {
             ReflectionUtil.CheckType(expectedType, typeof(string));
 
+            ConsumePayload(size, ref payloadBudget);
             return _database.ReadString(offset, size);
         }
 
-        private byte[] DecodeBytes(Type expectedType, long offset, int size)
+        private byte[] DecodeBytes(Type expectedType, long offset, int size, ref int payloadBudget)
         {
             ReflectionUtil.CheckType(expectedType, typeof(byte[]));
 
+            ConsumePayload(size, ref payloadBudget);
             return _database.Read(offset, size);
         }
 
@@ -396,6 +425,7 @@ namespace MaxMind.Db
         /// <param name="outOffset">The out offset.</param>
         /// <param name="depth">The current nesting depth.</param>
         /// <param name="budget">The remaining number of values that may be decoded.</param>
+        /// <param name="payloadBudget">The remaining payload budget in bytes.</param>
         /// <param name="injectables"></param>
         /// <param name="network"></param>
         /// <returns></returns>
@@ -406,6 +436,7 @@ namespace MaxMind.Db
             out long outOffset,
             int depth,
             ref int budget,
+            ref int payloadBudget,
             InjectableValues? injectables,
             Network? network
             )
@@ -422,14 +453,14 @@ namespace MaxMind.Db
                 (SourceGeneratorSupport.HasNonGenericDictionaryRegistration &&
                  SourceGeneratorSupport.TryGetDictionaryRegistration(expectedType, out _)))
             {
-                return DecodeMapToDictionary(expectedType, offset, size, out outOffset, depth, ref budget, injectables, network);
+                return DecodeMapToDictionary(expectedType, offset, size, out outOffset, depth, ref budget, ref payloadBudget, injectables, network);
             }
 
-            return DecodeMapToType(expectedType, offset, size, out outOffset, depth, ref budget, injectables, network);
+            return DecodeMapToType(expectedType, offset, size, out outOffset, depth, ref budget, ref payloadBudget, injectables, network);
         }
 
         private object DecodeMapToDictionary(Type expectedType, long offset, int size, out long outOffset,
-            int depth, ref int budget, InjectableValues? injectables, Network? network)
+            int depth, ref int budget, ref int payloadBudget, InjectableValues? injectables, Network? network)
         {
             // Fast path for Dictionary<string, string> (and parents).
             if (expectedType.IsAssignableFrom(typeof(Dictionary<string, string>)))
@@ -437,8 +468,8 @@ namespace MaxMind.Db
                 Dictionary<string, string> dic = new(size);
                 for (var i = 0; i < size; i++)
                 {
-                    var key = DecodeNested<string>(offset, out offset, depth + 1, ref budget, null, null);
-                    var value = DecodeNested<string>(offset, out offset, depth + 1, ref budget, injectables, network);
+                    var key = DecodeNested<string>(offset, out offset, depth + 1, ref budget, ref payloadBudget, null, null);
+                    var value = DecodeNested<string>(offset, out offset, depth + 1, ref budget, ref payloadBudget, injectables, network);
                     dic.Add(key, value);
                 }
 
@@ -452,8 +483,8 @@ namespace MaxMind.Db
                 Dictionary<string, object> dic = new(size);
                 for (var i = 0; i < size; i++)
                 {
-                    var key = DecodeNested<string>(offset, out offset, depth + 1, ref budget, null, null);
-                    var value = DecodeNested<object>(offset, out offset, depth + 1, ref budget, injectables, network);
+                    var key = DecodeNested<string>(offset, out offset, depth + 1, ref budget, ref payloadBudget, null, null);
+                    var value = DecodeNested<object>(offset, out offset, depth + 1, ref budget, ref payloadBudget, injectables, network);
                     dic.Add(key, value);
                 }
 
@@ -467,9 +498,9 @@ namespace MaxMind.Db
                 var generatedDictionary = registration.Factory(size);
                 for (var i = 0; i < size; i++)
                 {
-                    var key = Decode(registration.KeyType, offset, out offset, depth + 1, ref budget);
+                    var key = Decode(registration.KeyType, offset, out offset, depth + 1, ref budget, ref payloadBudget);
                     var value = Decode(
-                        registration.ValueType, offset, out offset, depth + 1, ref budget, injectables, network);
+                        registration.ValueType, offset, out offset, depth + 1, ref budget, ref payloadBudget, injectables, network);
                     registration.Add(generatedDictionary, key, value);
                 }
 
@@ -487,8 +518,8 @@ namespace MaxMind.Db
             var obj = (IDictionary)_dictionaryActivatorCreator.GetActivator(expectedType)(size);
             for (var i = 0; i < size; i++)
             {
-                var key = Decode(genericArgs[0], offset, out offset, depth + 1, ref budget);
-                var value = Decode(genericArgs[1], offset, out offset, depth + 1, ref budget, injectables, network);
+                var key = Decode(genericArgs[0], offset, out offset, depth + 1, ref budget, ref payloadBudget);
+                var value = Decode(genericArgs[1], offset, out offset, depth + 1, ref budget, ref payloadBudget, injectables, network);
                 obj.Add(key, value);
             }
 
@@ -503,6 +534,7 @@ namespace MaxMind.Db
             out long outOffset,
             int depth,
             ref int budget,
+            ref int payloadBudget,
             InjectableValues? injectables,
             Network? network
             )
@@ -522,12 +554,12 @@ namespace MaxMind.Db
 
             for (var i = 0; i < size; i++)
             {
-                var key = DecodeKey(offset, out offset, depth + 1, ref budget);
+                var key = DecodeKey(offset, out offset, depth + 1, ref budget, ref payloadBudget);
                 if (constructor.DeserializationParameters.TryGetValue(key, out var v))
                 {
                     var param = v;
                     var paramType = param.MemberType;
-                    var value = Decode(paramType, offset, out offset, depth + 1, ref budget, injectables, network);
+                    var value = Decode(paramType, offset, out offset, depth + 1, ref budget, ref payloadBudget, injectables, network);
                     parameters[param.Position] = value;
                 }
                 else
@@ -614,7 +646,7 @@ namespace MaxMind.Db
 
         private readonly TypeActivatorCreator _typeActivatorCreator;
 
-        private Key DecodeKey(long offset, out long outOffset, int depth, ref int budget)
+        private Key DecodeKey(long offset, out long outOffset, int depth, ref int budget, ref int payloadBudget)
         {
             var type = CtrlData(offset, out var size, out offset);
             switch (type)
@@ -627,9 +659,13 @@ namespace MaxMind.Db
                     CheckDepth(depth);
                     offset = DecodePointer(offset, size, out outOffset);
                     ConsumePointerTarget(ref budget);
-                    return DecodeKey(offset, out _, depth + 1, ref budget);
+                    return DecodeKey(offset, out _, depth + 1, ref budget, ref payloadBudget);
 
                 case ObjectType.Utf8String:
+                    // The key is hashed over its bytes now and compared later, so
+                    // a pointer-backed key re-hashes its target on every visit.
+                    // Charge its length so a fan-out of large keys is bounded.
+                    ConsumePayload(size, ref payloadBudget);
                     outOffset = offset + size;
                     return new Key(_database, offset, size);
 
@@ -680,12 +716,16 @@ namespace MaxMind.Db
         ///     Decodes the long.
         /// </summary>
         /// <returns></returns>
-        private long DecodeLong(Type expectedType, long offset, int size)
+        private long DecodeLong(Type expectedType, long offset, int size, ref int payloadBudget)
         {
             if (expectedType != typeof(long) && expectedType != typeof(long?))
             {
                 ReflectionUtil.CheckType(expectedType, typeof(long));
             }
+            // A well-formed uint32 is at most four bytes, but the size is not
+            // range-checked before the read, so charge the declared length to
+            // bound an oversized or fanned-out integer before it is read.
+            ConsumePayload(size, ref payloadBudget);
             return _database.ReadLong(offset, size);
         }
 
@@ -698,6 +738,7 @@ namespace MaxMind.Db
         /// <param name="outOffset">The out offset.</param>
         /// <param name="depth">The current nesting depth.</param>
         /// <param name="budget">The remaining number of values that may be decoded.</param>
+        /// <param name="payloadBudget">The remaining payload budget in bytes.</param>
         /// <param name="injectables"></param>
         /// <param name="network"></param>
         /// <returns></returns>
@@ -708,7 +749,7 @@ namespace MaxMind.Db
             Justification = "Generated collection registrations return before this runtime generic construction path. This path serves only the documented fallback for unregistered collection types, which is unsupported in NativeAOT applications.")]
 #endif
         private object DecodeArray(Type expectedType, int size, long offset, out long outOffset,
-            int depth, ref int budget, InjectableValues? injectables, Network? network)
+            int depth, ref int budget, ref int payloadBudget, InjectableValues? injectables, Network? network)
         {
             // Fast path for List<string> (and parents).
             if (expectedType != typeof(object) && expectedType.IsAssignableFrom(typeof(List<string>)))
@@ -716,7 +757,7 @@ namespace MaxMind.Db
                 List<string> list = new(size);
                 for (var i = 0; i < size; i++)
                 {
-                    var r = DecodeNested<string>(offset, out offset, depth + 1, ref budget, injectables, network);
+                    var r = DecodeNested<string>(offset, out offset, depth + 1, ref budget, ref payloadBudget, injectables, network);
                     list.Add(r);
                 }
 
@@ -730,7 +771,7 @@ namespace MaxMind.Db
                 List<object> list = new(size);
                 for (var i = 0; i < size; i++)
                 {
-                    var value = DecodeNested<object>(offset, out offset, depth + 1, ref budget, injectables, network);
+                    var value = DecodeNested<object>(offset, out offset, depth + 1, ref budget, ref payloadBudget, injectables, network);
                     list.Add(value);
                 }
 
@@ -745,7 +786,7 @@ namespace MaxMind.Db
                 for (var i = 0; i < size; i++)
                 {
                     var value = Decode(
-                        registration.ElementType, offset, out offset, depth + 1, ref budget, injectables, network);
+                        registration.ElementType, offset, out offset, depth + 1, ref budget, ref payloadBudget, injectables, network);
                     registration.Add(generatedCollection, value);
                 }
 
@@ -765,7 +806,7 @@ namespace MaxMind.Db
             var array = _listActivatorCreator.GetActivator(expectedType)(size);
             for (var i = 0; i < size; i++)
             {
-                var value = Decode(argType, offset, out offset, depth + 1, ref budget, injectables, network);
+                var value = Decode(argType, offset, out offset, depth + 1, ref budget, ref payloadBudget, injectables, network);
                 addMethod.Invoke(array, [value]);
             }
 
@@ -777,12 +818,13 @@ namespace MaxMind.Db
         ///     Decodes the uint64.
         /// </summary>
         /// <returns></returns>
-        private ulong DecodeUInt64(Type expectedType, long offset, int size)
+        private ulong DecodeUInt64(Type expectedType, long offset, int size, ref int payloadBudget)
         {
             if (expectedType != typeof(ulong) && expectedType != typeof(ulong?))
             {
                 ReflectionUtil.CheckType(expectedType, typeof(ulong));
             }
+            ConsumePayload(size, ref payloadBudget);
             return _database.ReadULong(offset, size);
         }
 
@@ -790,12 +832,14 @@ namespace MaxMind.Db
         ///     Decodes the big integer.
         /// </summary>
         /// <returns></returns>
-        private BigInteger DecodeBigInteger(Type expectedType, long offset, int size)
+        private BigInteger DecodeBigInteger(Type expectedType, long offset, int size, ref int payloadBudget)
         {
             if (expectedType != typeof(BigInteger) && expectedType != typeof(BigInteger?))
             {
                 ReflectionUtil.CheckType(expectedType, typeof(BigInteger));
             }
+            // Charge the payload before ReadBigInteger allocates its byte array.
+            ConsumePayload(size, ref payloadBudget);
             return _database.ReadBigInteger(offset, size);
         }
 

--- a/MaxMind.Db/Decoder.cs
+++ b/MaxMind.Db/Decoder.cs
@@ -96,6 +96,9 @@ namespace MaxMind.Db
         }
 
         // Check depth and charge declared children before reading or allocating.
+        // The budget is nonnegative on entry. CtrlData limits valueCount
+        // to less than 34 million, so subtraction cannot overflow. A negative
+        // result throws before another subtraction can occur.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void CheckContainer(int depth, int valueCount, ref int budget)
         {

--- a/MaxMind.Db/Decoder.cs
+++ b/MaxMind.Db/Decoder.cs
@@ -181,6 +181,10 @@ namespace MaxMind.Db
             return DecodeScalar(expectedType, type, offset, size, out outOffset, ref payloadBudget);
         }
 
+        /// <summary>
+        ///     Reads the type and size. For pointers, size contains the five
+        ///     raw control bits. For other types, it contains the expanded size.
+        /// </summary>
         private ObjectType CtrlData(long offset, out int size, out long outOffset)
         {
             if (offset >= _database.Length)
@@ -247,7 +251,7 @@ namespace MaxMind.Db
         /// <param name="injectables"></param>
         /// <param name="network"></param>
         /// <returns></returns>
-        /// <exception cref="Exception">Unable to handle type!</exception>
+        /// <exception cref="InvalidDatabaseException">The data is invalid or exceeds a decoding limit.</exception>
         private object DecodeContainer(
             Type expectedType,
             ObjectType type,
@@ -274,8 +278,8 @@ namespace MaxMind.Db
                     }
 
                     // The logical slot is already charged. Following a pointer
-                    // adds depth. Its target charges children or payload as
-                    // applicable. Boolean and double targets add no payload charge.
+                    // adds depth. Containers charge their children, and strings,
+                    // bytes, uint32, uint64, and uint128 charge their payload.
                     CheckDepth(depth);
                     return DecodePointerTarget(expectedType, pointer, depth + 1, ref budget, ref payloadBudget, injectables, network);
 
@@ -862,7 +866,6 @@ namespace MaxMind.Db
             {
                 ReflectionUtil.CheckType(expectedType, typeof(BigInteger));
             }
-            // Charge the payload before ReadBigInteger allocates its byte array.
             if (size > 16)
             {
                 throw new InvalidDatabaseException("The MaxMind DB file contains a uint128 larger than 16 bytes.");

--- a/MaxMind.Db/Decoder.cs
+++ b/MaxMind.Db/Decoder.cs
@@ -726,9 +726,10 @@ namespace MaxMind.Db
             {
                 ReflectionUtil.CheckType(expectedType, typeof(long));
             }
-            // A well-formed uint32 is at most four bytes, but the size is not
-            // range-checked before the read, so charge the declared length to
-            // bound an oversized or fanned-out integer before it is read.
+            if (size > 4)
+            {
+                throw new InvalidDatabaseException("The MaxMind DB file contains a uint32 larger than 4 bytes.");
+            }
             ConsumePayload(size, ref payloadBudget);
             return _database.ReadLong(offset, size);
         }
@@ -828,6 +829,10 @@ namespace MaxMind.Db
             {
                 ReflectionUtil.CheckType(expectedType, typeof(ulong));
             }
+            if (size > 8)
+            {
+                throw new InvalidDatabaseException("The MaxMind DB file contains a uint64 larger than 8 bytes.");
+            }
             ConsumePayload(size, ref payloadBudget);
             return _database.ReadULong(offset, size);
         }
@@ -843,6 +848,10 @@ namespace MaxMind.Db
                 ReflectionUtil.CheckType(expectedType, typeof(BigInteger));
             }
             // Charge the payload before ReadBigInteger allocates its byte array.
+            if (size > 16)
+            {
+                throw new InvalidDatabaseException("The MaxMind DB file contains a uint128 larger than 16 bytes.");
+            }
             ConsumePayload(size, ref payloadBudget);
             return _database.ReadBigInteger(offset, size);
         }

--- a/MaxMind.Db/Decoder.cs
+++ b/MaxMind.Db/Decoder.cs
@@ -174,7 +174,11 @@ namespace MaxMind.Db
             // Depth and value checks apply at containers and pointers.
             // Scalars charge payload where applicable.
             var type = CtrlData(offset, out var size, out offset);
-            return DecodeByType(expectedType, type, offset, size, out outOffset, depth, ref budget, ref payloadBudget, injectables, network);
+            if (type == ObjectType.Pointer || type == ObjectType.Map || type == ObjectType.Array)
+            {
+                return DecodeContainer(expectedType, type, offset, size, out outOffset, depth, ref budget, ref payloadBudget, injectables, network);
+            }
+            return DecodeScalar(expectedType, type, offset, size, out outOffset, ref payloadBudget);
         }
 
         private ObjectType CtrlData(long offset, out int size, out long outOffset)
@@ -224,7 +228,7 @@ namespace MaxMind.Db
         }
 
         /// <summary>
-        ///     Decodes the value by type.
+        ///     Decodes a pointer or container.
         /// </summary>
         /// <param name="expectedType"></param>
         /// <param name="type">The type.</param>
@@ -238,7 +242,7 @@ namespace MaxMind.Db
         /// <param name="network"></param>
         /// <returns></returns>
         /// <exception cref="Exception">Unable to handle type!</exception>
-        private object DecodeByType(
+        private object DecodeContainer(
             Type expectedType,
             ObjectType type,
             long offset,
@@ -278,6 +282,19 @@ namespace MaxMind.Db
                     CheckContainer(depth, size, ref budget);
                     return DecodeArray(expectedType, size, offset, out outOffset, depth, ref budget, ref payloadBudget, injectables, network);
 
+                default:
+                    throw new InvalidDatabaseException("Unable to handle type: " + type);
+            }
+        }
+
+        // Keep scalars out of the container dispatch frame. They need no depth,
+        // value budget, injectables, or network, and dominate ordinary records.
+        private object DecodeScalar(Type expectedType, ObjectType type, long offset, int size,
+            out long outOffset, ref int payloadBudget)
+        {
+            outOffset = offset + size;
+            switch (type)
+            {
                 case ObjectType.Boolean:
                     outOffset = offset;
                     return DecodeBoolean(expectedType, size);

--- a/MaxMind.Db/Decoder.cs
+++ b/MaxMind.Db/Decoder.cs
@@ -277,7 +277,7 @@ namespace MaxMind.Db
                     // adds depth. Its target charges children or payload as
                     // applicable. Boolean and double targets add no payload charge.
                     CheckDepth(depth);
-                    return Decode(expectedType, pointer, out _, depth + 1, ref budget, ref payloadBudget, injectables, network);
+                    return DecodePointerTarget(expectedType, pointer, depth + 1, ref budget, ref payloadBudget, injectables, network);
 
                 case ObjectType.Map:
                     // A map entry decodes a key and a value, so it costs two values.
@@ -291,6 +291,21 @@ namespace MaxMind.Db
                 default:
                     throw new InvalidDatabaseException("Unable to handle type: " + type);
             }
+        }
+
+        private object DecodePointerTarget(Type expectedType, long offset, int depth,
+            ref int budget, ref int payloadBudget, InjectableValues? injectables, Network? network)
+        {
+            var type = CtrlData(offset, out var size, out offset);
+            if (type == ObjectType.Pointer)
+            {
+                throw new InvalidDatabaseException("The MaxMind DB file contains a pointer to another pointer.");
+            }
+            if (type == ObjectType.Map || type == ObjectType.Array)
+            {
+                return DecodeContainer(expectedType, type, offset, size, out _, depth, ref budget, ref payloadBudget, injectables, network);
+            }
+            return DecodeScalar(expectedType, type, offset, size, out _, ref payloadBudget);
         }
 
         // Keep scalars out of the container dispatch frame. They need no depth,
@@ -656,16 +671,10 @@ namespace MaxMind.Db
             {
                 CheckDepth(depth);
                 offset = DecodePointer(offset, size, out outOffset);
-                while (true)
+                type = CtrlData(offset, out size, out offset);
+                if (type == ObjectType.Pointer)
                 {
-                    depth++;
-                    type = CtrlData(offset, out size, out offset);
-                    if (type != ObjectType.Pointer)
-                    {
-                        break;
-                    }
-                    CheckDepth(depth);
-                    offset = DecodePointer(offset, size, out _);
+                    throw new InvalidDatabaseException("The MaxMind DB file contains a pointer to another pointer.");
                 }
             }
             else
@@ -679,7 +688,7 @@ namespace MaxMind.Db
             }
 
             // Preserve the offset after the first pointer and charge the final
-            // string once, regardless of the number of pointers followed.
+            // string once.
             ConsumePayload(size, ref payloadBudget);
             return new Key(_database, offset, size);
         }

--- a/MaxMind.Db/Decoder.cs
+++ b/MaxMind.Db/Decoder.cs
@@ -46,19 +46,10 @@ namespace MaxMind.Db
         private readonly bool _followPointers;
         private readonly int[] _pointerValueOffset = [0, 0, 1 << 11, (1 << 19) + (1 << 11), 0];
 
-        // Per-lookup decode limits recommended by the MaxMind DB specification.
-        // The depth limit stops pointer cycles and over-deep data before the
-        // stack overflows (a StackOverflowException cannot be caught in .NET).
-        // The value limit stops a pointer fan-out, where nested pointers to
-        // shared targets would otherwise cost 2**depth decode operations. The
-        // payload limit stops payload amplification, where many pointers to one
-        // large string or bytes value would otherwise materialize N*size bytes
-        // from a small file; each string, bytes, and wide-integer value is
-        // charged by its length wherever it is decoded, so a re-decoded shared
-        // target is recharged. The running depth, value budget, and payload
-        // budget are passed through the decode call, so a single Decoder stays
-        // safe for concurrent lookups with no shared mutable state. The largest
-        // real records decode a few hundred values and a few kilobytes.
+        // Per-lookup limits recommended by the MaxMind DB specification.
+        // The root costs one value. Containers charge their declared children
+        // on every visit, including visits through shared pointers. Pointer
+        // follows add depth but no value charge of their own.
         private const int MaxDepth = 512;
         private const int MaxDecodedValues = 1 << 16;
         // Limit encoded string, bytes, uint32, uint64, and uint128 payload
@@ -117,19 +108,6 @@ namespace MaxMind.Db
             }
         }
 
-        // A pointer field is charged by its enclosing container. Its target is
-        // another decoded value and must be charged each time it is followed.
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void ConsumePointerTarget(ref int budget)
-        {
-            budget--;
-            if (budget < 0)
-            {
-                throw new InvalidDatabaseException(
-                    "The MaxMind DB file's data section exceeds the maximum number of values.");
-            }
-        }
-
         // Charge encoded payload before reading it, including each visit
         // to a shared target and each map key examined.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -172,12 +150,9 @@ namespace MaxMind.Db
         /// <returns>An object containing the data read from the stream</returns>
         internal T Decode<T>(long offset, out long outOffset, InjectableValues? injectables = null, Network? network = default) where T : class
         {
-            // The per-lookup decode limits are threaded as parameters (a value
-            // depth, a shared remaining-value budget, and a shared remaining
-            // payload-byte budget) rather than stored on the shared Decoder, so
-            // they add no thread-local access and keep the decoder safe for
-            // concurrent reads.
-            var budget = MaxDecodedValues;
+            // Budgets are local to each lookup, including concurrent lookups.
+            // Charge the root value before decoding its children.
+            var budget = MaxDecodedValues - 1;
             var payloadBudget = MaxPayloadBytes;
             return DecodeNested<T>(offset, out outOffset, 0, ref budget, ref payloadBudget, injectables, network);
         }
@@ -285,8 +260,12 @@ namespace MaxMind.Db
                         return pointer;
                     }
 
+                    // The pointer occupies a logical slot its container already
+                    // charged, so following it adds depth but no value. The
+                    // resolved value charges itself: a container charges its
+                    // declared size and a string, bytes, or wide integer
+                    // charges its length.
                     CheckDepth(depth);
-                    ConsumePointerTarget(ref budget);
                     return Decode(expectedType, pointer, out _, depth + 1, ref budget, ref payloadBudget, injectables, network);
 
                 case ObjectType.Map:
@@ -554,7 +533,7 @@ namespace MaxMind.Db
 
             for (var i = 0; i < size; i++)
             {
-                var key = DecodeKey(offset, out offset, depth + 1, ref budget, ref payloadBudget);
+                var key = DecodeKey(offset, out offset, depth + 1, ref payloadBudget);
                 if (constructor.DeserializationParameters.TryGetValue(key, out var v))
                 {
                     var param = v;
@@ -646,20 +625,20 @@ namespace MaxMind.Db
 
         private readonly TypeActivatorCreator _typeActivatorCreator;
 
-        private Key DecodeKey(long offset, out long outOffset, int depth, ref int budget, ref int payloadBudget)
+        private Key DecodeKey(long offset, out long outOffset, int depth, ref int payloadBudget)
         {
             var type = CtrlData(offset, out var size, out offset);
             switch (type)
             {
                 case ObjectType.Pointer:
-                    // A key can only be a string, so it cannot fan out and needs
-                    // no value budget. It can still point at another pointer, so
-                    // guard the depth to stop a pointer cycle from overflowing
-                    // the stack with an uncatchable StackOverflowException.
+                    // A key can only be a string, so it cannot fan out, and the
+                    // enclosing map already charged this key against the value
+                    // budget. It can still point at another pointer, so guard
+                    // the depth to stop a pointer cycle from overflowing the
+                    // stack with an uncatchable StackOverflowException.
                     CheckDepth(depth);
                     offset = DecodePointer(offset, size, out outOffset);
-                    ConsumePointerTarget(ref budget);
-                    return DecodeKey(offset, out _, depth + 1, ref budget, ref payloadBudget);
+                    return DecodeKey(offset, out _, depth + 1, ref payloadBudget);
 
                 case ObjectType.Utf8String:
                     // The key is hashed over its bytes now and compared later, so

--- a/MaxMind.Db/Decoder.cs
+++ b/MaxMind.Db/Decoder.cs
@@ -7,6 +7,7 @@ using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 
 #endregion
 
@@ -45,6 +46,81 @@ namespace MaxMind.Db
         private readonly bool _followPointers;
         private readonly int[] _pointerValueOffset = [0, 0, 1 << 11, (1 << 19) + (1 << 11), 0];
 
+        // Per-lookup decode limits recommended by the MaxMind DB specification.
+        // The depth limit stops pointer cycles and over-deep data before the
+        // stack overflows (a StackOverflowException cannot be caught in .NET).
+        // The value limit stops a pointer fan-out, where nested pointers to
+        // shared targets would otherwise cost 2**depth decode operations. The
+        // running depth and value budget are passed through the decode call, so
+        // a single Decoder stays safe for concurrent lookups with no shared
+        // mutable state. The largest real records decode a few hundred values.
+        private const int MaxDepth = 512;
+        private const int MaxDecodedValues = 1 << 16;
+        // The runtime stack can run out before the depth limit. Probe only
+        // at deeper levels to avoid the cost on shallow records.
+        private const int RuntimeStackCheckDepth = 32;
+
+        private static bool HasSufficientExecutionStack()
+        {
+#if NETSTANDARD2_0
+            // netstandard2.0 exposes only the throwing stack probe.
+            try
+            {
+                RuntimeHelpers.EnsureSufficientExecutionStack();
+                return true;
+            }
+            catch (InsufficientExecutionStackException)
+            {
+                return false;
+            }
+#else
+            return RuntimeHelpers.TryEnsureSufficientExecutionStack();
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void CheckDepth(int depth)
+        {
+            // Delay the stack probe beyond ordinary record depths. Rejection
+            // can mean excessive nesting or insufficient runtime stack space.
+            if (depth < RuntimeStackCheckDepth)
+            {
+                return;
+            }
+
+            if (depth > MaxDepth || !HasSufficientExecutionStack())
+            {
+                throw new InvalidDatabaseException(
+                    "The MaxMind DB file's data section exceeds the maximum depth.");
+            }
+        }
+
+        // Check depth and charge declared children before reading or allocating.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void CheckContainer(int depth, int valueCount, ref int budget)
+        {
+            CheckDepth(depth);
+            budget -= valueCount;
+            if (budget < 0)
+            {
+                throw new InvalidDatabaseException(
+                    "The MaxMind DB file's data section exceeds the maximum number of values.");
+            }
+        }
+
+        // A pointer field is charged by its enclosing container. Its target is
+        // another decoded value and must be charged each time it is followed.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void ConsumePointerTarget(ref int budget)
+        {
+            budget--;
+            if (budget < 0)
+            {
+                throw new InvalidDatabaseException(
+                    "The MaxMind DB file's data section exceeds the maximum number of values.");
+            }
+        }
+
         private readonly DictionaryActivatorCreator _dictionaryActivatorCreator;
         private readonly ListActivatorCreator _listActivatorCreator;
 
@@ -74,17 +150,28 @@ namespace MaxMind.Db
         /// <returns>An object containing the data read from the stream</returns>
         internal T Decode<T>(long offset, out long outOffset, InjectableValues? injectables = null, Network? network = default) where T : class
         {
-            if (Decode(typeof(T), offset, out outOffset, injectables, network) is not T decoded)
+            // The per-lookup decode limits are threaded as parameters (a value
+            // depth and a shared remaining-value budget) rather than stored on
+            // the shared Decoder, so they add no thread-local access and keep the
+            // decoder safe for concurrent reads.
+            var budget = MaxDecodedValues;
+            return DecodeNested<T>(offset, out outOffset, 0, ref budget, injectables, network);
+        }
+
+        private T DecodeNested<T>(long offset, out long outOffset, int depth, ref int budget, InjectableValues? injectables, Network? network) where T : class
+        {
+            if (Decode(typeof(T), offset, out outOffset, depth, ref budget, injectables, network) is not T decoded)
             {
                 throw new InvalidDatabaseException("The value cannot be decoded as " + typeof(T));
             }
             return decoded;
         }
 
-        private object Decode(Type expectedType, long offset, out long outOffset, InjectableValues? injectables = null, Network? network = null)
+        private object Decode(Type expectedType, long offset, out long outOffset, int depth, ref int budget, InjectableValues? injectables = null, Network? network = null)
         {
+            // Depth and value checks apply at containers and pointers.
             var type = CtrlData(offset, out var size, out offset);
-            return DecodeByType(expectedType, type, offset, size, out outOffset, injectables, network);
+            return DecodeByType(expectedType, type, offset, size, out outOffset, depth, ref budget, injectables, network);
         }
 
         private ObjectType CtrlData(long offset, out int size, out long outOffset)
@@ -141,6 +228,8 @@ namespace MaxMind.Db
         /// <param name="offset">The offset.</param>
         /// <param name="size">The size.</param>
         /// <param name="outOffset">The out offset</param>
+        /// <param name="depth">The current nesting depth.</param>
+        /// <param name="budget">The remaining number of values that may be decoded.</param>
         /// <param name="injectables"></param>
         /// <param name="network"></param>
         /// <returns></returns>
@@ -151,6 +240,8 @@ namespace MaxMind.Db
             long offset,
             int size,
             out long outOffset,
+            int depth,
+            ref int budget,
             InjectableValues? injectables,
             Network? network
             )
@@ -167,14 +258,18 @@ namespace MaxMind.Db
                         return pointer;
                     }
 
-                    var result = Decode(expectedType, pointer, out _, injectables, network);
-                    return result;
+                    CheckDepth(depth);
+                    ConsumePointerTarget(ref budget);
+                    return Decode(expectedType, pointer, out _, depth + 1, ref budget, injectables, network);
 
                 case ObjectType.Map:
-                    return DecodeMap(expectedType, offset, size, out outOffset, injectables, network);
+                    // A map entry decodes a key and a value, so it costs two values.
+                    CheckContainer(depth, size * 2, ref budget);
+                    return DecodeMap(expectedType, offset, size, out outOffset, depth, ref budget, injectables, network);
 
                 case ObjectType.Array:
-                    return DecodeArray(expectedType, size, offset, out outOffset, injectables, network);
+                    CheckContainer(depth, size, ref budget);
+                    return DecodeArray(expectedType, size, offset, out outOffset, depth, ref budget, injectables, network);
 
                 case ObjectType.Boolean:
                     outOffset = offset;
@@ -299,6 +394,8 @@ namespace MaxMind.Db
         /// <param name="offset">The offset.</param>
         /// <param name="size">The size.</param>
         /// <param name="outOffset">The out offset.</param>
+        /// <param name="depth">The current nesting depth.</param>
+        /// <param name="budget">The remaining number of values that may be decoded.</param>
         /// <param name="injectables"></param>
         /// <param name="network"></param>
         /// <returns></returns>
@@ -307,6 +404,8 @@ namespace MaxMind.Db
             long offset,
             int size,
             out long outOffset,
+            int depth,
+            ref int budget,
             InjectableValues? injectables,
             Network? network
             )
@@ -323,14 +422,14 @@ namespace MaxMind.Db
                 (SourceGeneratorSupport.HasNonGenericDictionaryRegistration &&
                  SourceGeneratorSupport.TryGetDictionaryRegistration(expectedType, out _)))
             {
-                return DecodeMapToDictionary(expectedType, offset, size, out outOffset, injectables, network);
+                return DecodeMapToDictionary(expectedType, offset, size, out outOffset, depth, ref budget, injectables, network);
             }
 
-            return DecodeMapToType(expectedType, offset, size, out outOffset, injectables, network);
+            return DecodeMapToType(expectedType, offset, size, out outOffset, depth, ref budget, injectables, network);
         }
 
         private object DecodeMapToDictionary(Type expectedType, long offset, int size, out long outOffset,
-            InjectableValues? injectables, Network? network)
+            int depth, ref int budget, InjectableValues? injectables, Network? network)
         {
             // Fast path for Dictionary<string, string> (and parents).
             if (expectedType.IsAssignableFrom(typeof(Dictionary<string, string>)))
@@ -338,8 +437,8 @@ namespace MaxMind.Db
                 Dictionary<string, string> dic = new(size);
                 for (var i = 0; i < size; i++)
                 {
-                    var key = Decode<string>(offset, out offset);
-                    var value = Decode<string>(offset, out offset, injectables, network);
+                    var key = DecodeNested<string>(offset, out offset, depth + 1, ref budget, null, null);
+                    var value = DecodeNested<string>(offset, out offset, depth + 1, ref budget, injectables, network);
                     dic.Add(key, value);
                 }
 
@@ -353,8 +452,8 @@ namespace MaxMind.Db
                 Dictionary<string, object> dic = new(size);
                 for (var i = 0; i < size; i++)
                 {
-                    var key = Decode<string>(offset, out offset);
-                    var value = Decode<object>(offset, out offset, injectables, network);
+                    var key = DecodeNested<string>(offset, out offset, depth + 1, ref budget, null, null);
+                    var value = DecodeNested<object>(offset, out offset, depth + 1, ref budget, injectables, network);
                     dic.Add(key, value);
                 }
 
@@ -368,9 +467,9 @@ namespace MaxMind.Db
                 var generatedDictionary = registration.Factory(size);
                 for (var i = 0; i < size; i++)
                 {
-                    var key = Decode(registration.KeyType, offset, out offset);
+                    var key = Decode(registration.KeyType, offset, out offset, depth + 1, ref budget);
                     var value = Decode(
-                        registration.ValueType, offset, out offset, injectables, network);
+                        registration.ValueType, offset, out offset, depth + 1, ref budget, injectables, network);
                     registration.Add(generatedDictionary, key, value);
                 }
 
@@ -388,8 +487,8 @@ namespace MaxMind.Db
             var obj = (IDictionary)_dictionaryActivatorCreator.GetActivator(expectedType)(size);
             for (var i = 0; i < size; i++)
             {
-                var key = Decode(genericArgs[0], offset, out offset);
-                var value = Decode(genericArgs[1], offset, out offset, injectables, network);
+                var key = Decode(genericArgs[0], offset, out offset, depth + 1, ref budget);
+                var value = Decode(genericArgs[1], offset, out offset, depth + 1, ref budget, injectables, network);
                 obj.Add(key, value);
             }
 
@@ -402,6 +501,8 @@ namespace MaxMind.Db
             long offset,
             int size,
             out long outOffset,
+            int depth,
+            ref int budget,
             InjectableValues? injectables,
             Network? network
             )
@@ -421,17 +522,17 @@ namespace MaxMind.Db
 
             for (var i = 0; i < size; i++)
             {
-                var key = DecodeKey(offset, out offset);
+                var key = DecodeKey(offset, out offset, depth + 1, ref budget);
                 if (constructor.DeserializationParameters.TryGetValue(key, out var v))
                 {
                     var param = v;
                     var paramType = param.MemberType;
-                    var value = Decode(paramType, offset, out offset, injectables, network);
+                    var value = Decode(paramType, offset, out offset, depth + 1, ref budget, injectables, network);
                     parameters[param.Position] = value;
                 }
                 else
                 {
-                    offset = NextValueOffset(offset, 1);
+                    offset = NextValueOffset(offset, 1, depth + 1, ref budget);
                 }
             }
 
@@ -513,14 +614,20 @@ namespace MaxMind.Db
 
         private readonly TypeActivatorCreator _typeActivatorCreator;
 
-        private Key DecodeKey(long offset, out long outOffset)
+        private Key DecodeKey(long offset, out long outOffset, int depth, ref int budget)
         {
             var type = CtrlData(offset, out var size, out offset);
             switch (type)
             {
                 case ObjectType.Pointer:
+                    // A key can only be a string, so it cannot fan out and needs
+                    // no value budget. It can still point at another pointer, so
+                    // guard the depth to stop a pointer cycle from overflowing
+                    // the stack with an uncatchable StackOverflowException.
+                    CheckDepth(depth);
                     offset = DecodePointer(offset, size, out outOffset);
-                    return DecodeKey(offset, out _);
+                    ConsumePointerTarget(ref budget);
+                    return DecodeKey(offset, out _, depth + 1, ref budget);
 
                 case ObjectType.Utf8String:
                     outOffset = offset + size;
@@ -531,15 +638,12 @@ namespace MaxMind.Db
             }
         }
 
-        private long NextValueOffset(long offset, int numberToSkip)
+        // The enclosing container charged numberToSkip. Skipped containers
+        // still charge their children and undergo structural depth checks.
+        private long NextValueOffset(long offset, int numberToSkip, int depth, ref int budget)
         {
-            while (true)
+            while (numberToSkip > 0)
             {
-                if (numberToSkip == 0)
-                {
-                    return offset;
-                }
-
                 var type = CtrlData(offset, out var size, out offset);
                 switch (type)
                 {
@@ -549,11 +653,13 @@ namespace MaxMind.Db
                         break;
 
                     case ObjectType.Map:
-                        numberToSkip += 2 * size;
+                        CheckContainer(depth, 2 * size, ref budget);
+                        offset = NextValueOffset(offset, 2 * size, depth + 1, ref budget);
                         break;
 
                     case ObjectType.Array:
-                        numberToSkip += size;
+                        CheckContainer(depth, size, ref budget);
+                        offset = NextValueOffset(offset, size, depth + 1, ref budget);
                         break;
 
                     case ObjectType.Boolean:
@@ -566,6 +672,8 @@ namespace MaxMind.Db
 
                 numberToSkip--;
             }
+
+            return offset;
         }
 
         /// <summary>
@@ -588,6 +696,8 @@ namespace MaxMind.Db
         /// <param name="size">The size.</param>
         /// <param name="offset">The offset.</param>
         /// <param name="outOffset">The out offset.</param>
+        /// <param name="depth">The current nesting depth.</param>
+        /// <param name="budget">The remaining number of values that may be decoded.</param>
         /// <param name="injectables"></param>
         /// <param name="network"></param>
         /// <returns></returns>
@@ -598,7 +708,7 @@ namespace MaxMind.Db
             Justification = "Generated collection registrations return before this runtime generic construction path. This path serves only the documented fallback for unregistered collection types, which is unsupported in NativeAOT applications.")]
 #endif
         private object DecodeArray(Type expectedType, int size, long offset, out long outOffset,
-            InjectableValues? injectables, Network? network)
+            int depth, ref int budget, InjectableValues? injectables, Network? network)
         {
             // Fast path for List<string> (and parents).
             if (expectedType != typeof(object) && expectedType.IsAssignableFrom(typeof(List<string>)))
@@ -606,7 +716,7 @@ namespace MaxMind.Db
                 List<string> list = new(size);
                 for (var i = 0; i < size; i++)
                 {
-                    var r = Decode<string>(offset, out offset, injectables, network);
+                    var r = DecodeNested<string>(offset, out offset, depth + 1, ref budget, injectables, network);
                     list.Add(r);
                 }
 
@@ -620,7 +730,7 @@ namespace MaxMind.Db
                 List<object> list = new(size);
                 for (var i = 0; i < size; i++)
                 {
-                    var value = Decode<object>(offset, out offset, injectables, network);
+                    var value = DecodeNested<object>(offset, out offset, depth + 1, ref budget, injectables, network);
                     list.Add(value);
                 }
 
@@ -635,7 +745,7 @@ namespace MaxMind.Db
                 for (var i = 0; i < size; i++)
                 {
                     var value = Decode(
-                        registration.ElementType, offset, out offset, injectables, network);
+                        registration.ElementType, offset, out offset, depth + 1, ref budget, injectables, network);
                     registration.Add(generatedCollection, value);
                 }
 
@@ -655,7 +765,7 @@ namespace MaxMind.Db
             var array = _listActivatorCreator.GetActivator(expectedType)(size);
             for (var i = 0; i < size; i++)
             {
-                var value = Decode(argType, offset, out offset, injectables, network);
+                var value = Decode(argType, offset, out offset, depth + 1, ref budget, injectables, network);
                 addMethod.Invoke(array, [value]);
             }
 

--- a/MaxMind.Db/Decoder.cs
+++ b/MaxMind.Db/Decoder.cs
@@ -260,11 +260,9 @@ namespace MaxMind.Db
                         return pointer;
                     }
 
-                    // The pointer occupies a logical slot its container already
-                    // charged, so following it adds depth but no value. The
-                    // resolved value charges itself: a container charges its
-                    // declared size and a string, bytes, or wide integer
-                    // charges its length.
+                    // The logical slot is already charged. Following a pointer
+                    // adds depth. Its target charges children or payload as
+                    // applicable. Boolean and double targets add no payload charge.
                     CheckDepth(depth);
                     return Decode(expectedType, pointer, out _, depth + 1, ref budget, ref payloadBudget, injectables, network);
 

--- a/MaxMind.Db/DictionaryActivatorCreator.cs
+++ b/MaxMind.Db/DictionaryActivatorCreator.cs
@@ -12,10 +12,10 @@ namespace MaxMind.Db
 {
     internal sealed class DictionaryActivatorCreator
     {
-        private readonly ConcurrentDictionary<Type, ObjectActivator> _dictActivators =
+        private readonly ConcurrentDictionary<Type, Func<int, object>> _dictActivators =
             new();
 
-        internal ObjectActivator GetActivator(Type expectedType)
+        internal Func<int, object> GetActivator(Type expectedType)
             => _dictActivators.GetOrAdd(expectedType, DictionaryActivator);
 
 #if NET8_0_OR_GREATER
@@ -28,7 +28,7 @@ namespace MaxMind.Db
             "IL2070",
             Justification = "Generated dictionary registrations return before this reflection path. This path serves only the documented fallback for unregistered dictionary types, which is unsupported in trimmed applications.")]
 #endif
-        private static ObjectActivator DictionaryActivator(Type expectedType)
+        private static Func<int, object> DictionaryActivator(Type expectedType)
         {
             var genericArgs = expectedType.GetGenericArguments();
             ConstructorInfo? constructor;
@@ -45,7 +45,7 @@ namespace MaxMind.Db
             }
             if (constructor == null)
                 throw new DeserializationException($"Unable to find default constructor for {expectedType}");
-            return ReflectionUtil.CreateActivator(constructor);
+            return ReflectionUtil.CreateCapacityActivator(constructor);
         }
     }
 }

--- a/MaxMind.Db/ListActivatorCreator.cs
+++ b/MaxMind.Db/ListActivatorCreator.cs
@@ -11,10 +11,10 @@ namespace MaxMind.Db
 {
     internal sealed class ListActivatorCreator
     {
-        private readonly ConcurrentDictionary<Type, ObjectActivator> _listActivators =
+        private readonly ConcurrentDictionary<Type, Func<int, object>> _listActivators =
             new();
 
-        internal ObjectActivator GetActivator(Type expectedType)
+        internal Func<int, object> GetActivator(Type expectedType)
             => _listActivators.GetOrAdd(expectedType, ListActivator);
 
 #if NET8_0_OR_GREATER
@@ -27,7 +27,7 @@ namespace MaxMind.Db
             "IL2070",
             Justification = "Generated collection registrations return before this reflection path. This path serves only the documented fallback for unregistered collection types, which is unsupported in trimmed applications.")]
 #endif
-        private static ObjectActivator ListActivator(Type expectedType)
+        private static Func<int, object> ListActivator(Type expectedType)
         {
             var genericArgs = expectedType.GetGenericArguments();
             var argType = genericArgs.Length switch
@@ -51,7 +51,7 @@ namespace MaxMind.Db
             }
             if (constructor == null)
                 throw new DeserializationException($"Unable to find default constructor for {expectedType}");
-            return ReflectionUtil.CreateActivator(constructor);
+            return ReflectionUtil.CreateCapacityActivator(constructor);
         }
     }
 }

--- a/MaxMind.Db/MemoryMapBuffer.cs
+++ b/MaxMind.Db/MemoryMapBuffer.cs
@@ -263,8 +263,8 @@ namespace MaxMind.Db
         {
             if (offset < 0 || (ulong)offset + (ulong)count > (ulong)Length)
             {
-                throw new ArgumentOutOfRangeException(nameof(offset),
-                    "Attempt to read beyond the end of the MemoryMappedFile.");
+                throw new InvalidDatabaseException(
+                    "Attempt to read beyond the end of the database.");
             }
             return new ReadOnlySpan<byte>((byte*)_ptr + offset, count);
         }
@@ -302,8 +302,8 @@ namespace MaxMind.Db
 #else
             if ((ulong)offset >= (ulong)Length)
             {
-                throw new ArgumentOutOfRangeException(nameof(offset),
-                    "Attempt to read beyond the end of the MemoryMappedFile.");
+                throw new InvalidDatabaseException(
+                    "Attempt to read beyond the end of the database.");
             }
             unsafe
             {
@@ -326,8 +326,8 @@ namespace MaxMind.Db
             }
             if (offset < 0 || (ulong)offset + (ulong)count > (ulong)Length)
             {
-                throw new ArgumentOutOfRangeException(nameof(offset),
-                    "Attempt to read beyond the end of the MemoryMappedFile.");
+                throw new InvalidDatabaseException(
+                    "Attempt to read beyond the end of the database.");
             }
             var bytes = new byte[count];
             _view.ReadArray(offset, bytes, 0, count);

--- a/MaxMind.Db/MemoryMapBuffer.cs
+++ b/MaxMind.Db/MemoryMapBuffer.cs
@@ -261,14 +261,23 @@ namespace MaxMind.Db
         // that databases larger than 2 GiB still work (Span length is int).
         private unsafe ReadOnlySpan<byte> GetSpan(long offset, int count)
         {
+            CheckBounds(offset, count);
+            return new ReadOnlySpan<byte>((byte*)_ptr + offset, count);
+        }
+#endif
+
+        // Check the database length, since the view accessor can include
+        // padding beyond the file. GetSpan shares this check on other targets.
+        // Unsigned addition prevents a large offset from wrapping negative
+        // and passing a signed bounds comparison.
+        private void CheckBounds(long offset, int count)
+        {
             if (offset < 0 || (ulong)offset + (ulong)count > (ulong)Length)
             {
                 throw new InvalidDatabaseException(
                     "Attempt to read beyond the end of the database.");
             }
-            return new ReadOnlySpan<byte>((byte*)_ptr + offset, count);
         }
-#endif
 
         internal byte[] Read(long offset, int count)
         {
@@ -282,6 +291,7 @@ namespace MaxMind.Db
             {
                 return Array.Empty<byte>();
             }
+            CheckBounds(offset, count);
             var bytes = new byte[count];
             _view.ReadArray(offset, bytes, 0, count);
             return bytes;
@@ -298,6 +308,7 @@ namespace MaxMind.Db
             }
 
 #if NETSTANDARD2_0
+            CheckBounds(offset, 1);
             return _view.ReadByte(offset);
 #else
             if ((ulong)offset >= (ulong)Length)
@@ -324,11 +335,7 @@ namespace MaxMind.Db
             {
                 return string.Empty;
             }
-            if (offset < 0 || (ulong)offset + (ulong)count > (ulong)Length)
-            {
-                throw new InvalidDatabaseException(
-                    "Attempt to read beyond the end of the database.");
-            }
+            CheckBounds(offset, count);
             var bytes = new byte[count];
             _view.ReadArray(offset, bytes, 0, count);
             return Encoding.UTF8.GetString(bytes);
@@ -348,6 +355,7 @@ namespace MaxMind.Db
             }
 
 #if NETSTANDARD2_0
+            CheckBounds(offset, 4);
             return _view.ReadByte(offset) << 24 |
                    _view.ReadByte(offset + 1) << 16 |
                    _view.ReadByte(offset + 2) << 8 |
@@ -372,6 +380,10 @@ namespace MaxMind.Db
             }
 
 #if NETSTANDARD2_0
+            if (count == 1 || count == 2 || count == 3)
+            {
+                CheckBounds(offset, count);
+            }
             return count switch
             {
                 0 => 0,
@@ -411,6 +423,7 @@ namespace MaxMind.Db
         internal int HashBytes(long offset, int count)
         {
 #if NETSTANDARD2_0
+            CheckBounds(offset, count);
             var code = 17;
             for (var i = 0; i < count; i++)
             {
@@ -432,6 +445,8 @@ namespace MaxMind.Db
         internal bool EqualsBytes(long offset, MemoryMapBuffer other, long otherOffset, int count)
         {
 #if NETSTANDARD2_0
+            CheckBounds(offset, count);
+            other.CheckBounds(otherOffset, count);
             for (var i = 0; i < count; i++)
             {
                 if (_view.ReadByte(offset + i) != other._view.ReadByte(otherOffset + i))
@@ -450,6 +465,7 @@ namespace MaxMind.Db
         internal bool EqualsBytes(long offset, byte[] other, int otherOffset, int count)
         {
 #if NETSTANDARD2_0
+            CheckBounds(offset, count);
             for (var i = 0; i < count; i++)
             {
                 if (_view.ReadByte(offset + i) != other[otherOffset + i])
@@ -512,6 +528,7 @@ namespace MaxMind.Db
             }
 
 #if NETSTANDARD2_0
+            CheckBounds(offset, size);
             long val = 0;
             for (var i = 0; i < size; i++)
             {
@@ -540,6 +557,7 @@ namespace MaxMind.Db
             }
 
 #if NETSTANDARD2_0
+            CheckBounds(offset, size);
             ulong val = 0;
             for (var i = 0; i < size; i++)
             {

--- a/MaxMind.Db/MemoryMapBuffer.cs
+++ b/MaxMind.Db/MemoryMapBuffer.cs
@@ -268,8 +268,9 @@ namespace MaxMind.Db
 
         // Check the database length, since the view accessor can include
         // padding beyond the file. GetSpan shares this check on other targets.
-        // Unsigned addition prevents a large offset from wrapping negative
-        // and passing a signed bounds comparison.
+        // Reject negative offsets before unsigned addition, which could wrap.
+        // For nonnegative offsets and counts, the unsigned sum cannot overflow
+        // and keeps offsets beyond long.MaxValue outside the database.
         private void CheckBounds(long offset, int count)
         {
             if (offset < 0 || (ulong)offset + (ulong)count > (ulong)Length)
@@ -311,6 +312,7 @@ namespace MaxMind.Db
             CheckBounds(offset, 1);
             return _view.ReadByte(offset);
 #else
+            // This single-byte check rejects negative offsets and needs no addition.
             if ((ulong)offset >= (ulong)Length)
             {
                 throw new InvalidDatabaseException(
@@ -380,6 +382,7 @@ namespace MaxMind.Db
             }
 
 #if NETSTANDARD2_0
+            // Zero reads nothing. Four delegates to ReadInt, which checks bounds.
             if (count == 1 || count == 2 || count == 3)
             {
                 CheckBounds(offset, count);

--- a/MaxMind.Db/ReflectionUtil.cs
+++ b/MaxMind.Db/ReflectionUtil.cs
@@ -47,6 +47,28 @@ namespace MaxMind.Db
             return (ObjectActivator)lambda.Compile();
         }
 
+        // Collection factories take a capacity directly, without a boxed
+        // integer and a temporary argument array on each decode.
+        internal static Func<int, object> CreateCapacityActivator(ConstructorInfo constructor)
+        {
+            if (constructor == null)
+            {
+                throw new ArgumentNullException(nameof(constructor));
+            }
+
+            var capacity = Expression.Parameter(typeof(int), "capacity");
+            NewExpression create;
+            if (constructor.GetParameters().Length == 0)
+            {
+                create = Expression.New(constructor);
+            }
+            else
+            {
+                create = Expression.New(constructor, capacity);
+            }
+            return Expression.Lambda<Func<int, object>>(create, capacity).Compile();
+        }
+
         /// <summary>
         ///     Creates a compiled activator that uses <c>MemberInit</c> expressions
         ///     to set properties on an object created via a parameterless constructor.

--- a/MaxMind.Db/ReflectionUtil.cs
+++ b/MaxMind.Db/ReflectionUtil.cs
@@ -93,8 +93,15 @@ namespace MaxMind.Db
             }
             if (!expected.IsAssignableFrom(from))
             {
-                throw new DeserializationException($"Could not convert '{from}' to '{expected}'.");
+                ThrowCannotConvert(expected, from);
             }
+        }
+
+        // Keep error-message construction out of callers that inline CheckType.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowCannotConvert(Type expected, Type from)
+        {
+            throw new DeserializationException($"Could not convert '{from}' to '{expected}'.");
         }
     }
 }

--- a/MaxMind.Db/ReflectionUtil.cs
+++ b/MaxMind.Db/ReflectionUtil.cs
@@ -66,6 +66,7 @@ namespace MaxMind.Db
             {
                 create = Expression.New(constructor, capacity);
             }
+            // The Compile limitation described in CreateActivator also applies here.
             return Expression.Lambda<Func<int, object>>(create, capacity).Compile();
         }
 

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -25,11 +25,11 @@
   the reflection path before this release and is now consistent across both.
 - Added decoding limits to prevent crafted databases from consuming excessive
   time and memory. Each lookup and metadata read allows at most 65,536 decoded
-  values and 2 MiB of combined string, bytes, uint32, uint64, and uint128 payload. Exceeding a limit or
-  encountering a pointer cycle throws `InvalidDatabaseException`. These limits
-  reject some previously accepted databases, including those with a string or
-  bytes value larger than 2 MiB. Available stack space can impose a lower
-  nesting limit.
+  values, 512 nesting levels, and 2 MiB of combined string, bytes, uint32,
+  uint64, and uint128 payload. Exceeding a limit or encountering a pointer cycle
+  throws `InvalidDatabaseException`. These limits reject some previously
+  accepted databases, including those with a string or bytes value larger than
+  2 MiB. Available stack space can impose a lower nesting limit.
 - Truncated or out-of-bounds data reads now throw `InvalidDatabaseException`
   instead of `ArgumentOutOfRangeException`. This also prevents incorrect decoded
   values on `netstandard2.0`.

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -31,7 +31,8 @@
   bytes value larger than 2 MiB. Available stack space can impose a lower
   nesting limit.
 - Truncated or out-of-bounds data reads now throw `InvalidDatabaseException`
-  instead of `ArgumentOutOfRangeException`.
+  instead of `ArgumentOutOfRangeException`. This also prevents incorrect decoded
+  values on `netstandard2.0`.
 
 ## 5.1.0 (2026-05-22)
 

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -24,9 +24,12 @@
   during property-based activation instead of keeping its default. This affected
   the reflection path before this release and is now consistent across both.
 - Added decoding limits to prevent crafted databases from consuming excessive
-  time and memory during lookups and metadata reads. Excessive work and
-  pointer cycles throw `InvalidDatabaseException`. Available stack space can
-  impose a lower nesting limit.
+  time and memory. Each lookup and metadata read has a 2 MiB budget for combined
+  string, bytes, uint32, uint64, and uint128 payload. Exceeding a limit or
+  encountering a pointer cycle throws `InvalidDatabaseException`. These limits
+  reject some previously accepted databases, including those with a string or
+  bytes value larger than 2 MiB. Available stack space can impose a lower
+  nesting limit.
 ## 5.1.0 (2026-05-22)
 
 - `FileAccessMode.MemoryMapped` now creates an unnamed file-backed memory-mapped

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -24,8 +24,8 @@
   during property-based activation instead of keeping its default. This affected
   the reflection path before this release and is now consistent across both.
 - Added decoding limits to prevent crafted databases from consuming excessive
-  time and memory. Each lookup and metadata read has a 2 MiB budget for combined
-  string, bytes, uint32, uint64, and uint128 payload. Exceeding a limit or
+  time and memory. Each lookup and metadata read allows at most 65,536 decoded
+  values and 2 MiB of combined string, bytes, uint32, uint64, and uint128 payload. Exceeding a limit or
   encountering a pointer cycle throws `InvalidDatabaseException`. These limits
   reject some previously accepted databases, including those with a string or
   bytes value larger than 2 MiB. Available stack space can impose a lower

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -2,6 +2,8 @@
 
 ## 5.2.0 (YYYY-MM-DD)
 
+- Oversized unsigned integers now throw `InvalidDatabaseException` instead of
+  returning truncated or out-of-range values.
 - Added NativeAOT and trimming support for C# model deserialization. The NuGet
   package now includes a source generator for constructor-based and
   property-based models, including models with annotated properties inherited

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -23,7 +23,10 @@
 - Fixed a `[MapKey(..., true)]` member of a non-nullable value type throwing
   during property-based activation instead of keeping its default. This affected
   the reflection path before this release and is now consistent across both.
-
+- Added decoding limits to prevent crafted databases from consuming excessive
+  time and memory during lookups and metadata reads. Excessive work and
+  pointer cycles throw `InvalidDatabaseException`. Available stack space can
+  impose a lower nesting limit.
 ## 5.1.0 (2026-05-22)
 
 - `FileAccessMode.MemoryMapped` now creates an unnamed file-backed memory-mapped

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -3,8 +3,7 @@
 ## 5.2.0 (YYYY-MM-DD)
 
 - Fixed decoding of some valid four-byte data pointers.
-- Oversized unsigned integers now throw `InvalidDatabaseException` instead of
-  returning truncated or out-of-range values.
+- Fixed truncated or out-of-range results when decoding oversized integers.
 - Added NativeAOT and trimming support for C# model deserialization. The NuGet
   package now includes a source generator for constructor-based and
   property-based models, including models with annotated properties inherited
@@ -30,14 +29,18 @@
   the reflection path before this release and is now consistent across both.
 - Added decoding limits to prevent crafted databases from consuming excessive
   time and memory. Each lookup and metadata read allows at most 65,536 decoded
-  values, 512 nesting levels, and 2 MiB of combined string, bytes, uint32,
-  uint64, and uint128 payload. Exceeding a limit or encountering a pointer cycle
-  throws `InvalidDatabaseException`. These limits reject some previously
-  accepted databases, including those with a string or bytes value larger than 2
-  MiB. Available stack space can impose a lower nesting limit.
+  values, 512 nesting levels (including pointer follows), and 2 MiB of combined
+  string, bytes, uint32, uint64, and uint128 payload. Exceeding a limit or
+  encountering a pointer cycle throws `InvalidDatabaseException`. These limits
+  reject some previously accepted databases, including those with a string or
+  bytes value larger than 2 MiB. Available stack space can impose a lower
+  nesting limit.
+- Pointers that point directly to other pointers now throw
+  `InvalidDatabaseException`.
 - Truncated or out-of-bounds data reads now throw `InvalidDatabaseException`
   instead of `ArgumentOutOfRangeException`. This also prevents incorrect decoded
-  values on `netstandard2.0`.
+  values on `netstandard2.0`. Update error handlers to catch
+  `InvalidDatabaseException`.
 
 ## 5.1.0 (2026-05-22)
 

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -30,6 +30,9 @@
   reject some previously accepted databases, including those with a string or
   bytes value larger than 2 MiB. Available stack space can impose a lower
   nesting limit.
+- Truncated or out-of-bounds data reads now throw `InvalidDatabaseException`
+  instead of `ArgumentOutOfRangeException`.
+
 ## 5.1.0 (2026-05-22)
 
 - `FileAccessMode.MemoryMapped` now creates an unnamed file-backed memory-mapped

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -2,6 +2,7 @@
 
 ## 5.2.0 (YYYY-MM-DD)
 
+- Fixed decoding of some valid four-byte data pointers.
 - Oversized unsigned integers now throw `InvalidDatabaseException` instead of
   returning truncated or out-of-range values.
 - Added NativeAOT and trimming support for C# model deserialization. The NuGet

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -11,7 +11,8 @@
   collection types used directly with `Find<T>` and `FindAll<T>`.
 - Reused immutable source-generated activation metadata across readers, reducing
   the time and allocation cost of the first model lookup on a new reader.
-- Improved lookup performance.
+- Improved lookup performance and reduced allocations when creating collections
+  through reflection.
 - Enabled trim, AOT, and single-file compatibility analysis.
 - Added the `MMDBSG001` through `MMDBSG016` diagnostics, which report model
   shapes the generator cannot support so that they are caught at build time

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -33,8 +33,8 @@
   values, 512 nesting levels, and 2 MiB of combined string, bytes, uint32,
   uint64, and uint128 payload. Exceeding a limit or encountering a pointer cycle
   throws `InvalidDatabaseException`. These limits reject some previously
-  accepted databases, including those with a string or bytes value larger than
-  2 MiB. Available stack space can impose a lower nesting limit.
+  accepted databases, including those with a string or bytes value larger than 2
+  MiB. Available stack space can impose a lower nesting limit.
 - Truncated or out-of-bounds data reads now throw `InvalidDatabaseException`
   instead of `ArgumentOutOfRangeException`. This also prevents incorrect decoded
   values on `netstandard2.0`.

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -11,6 +11,7 @@
   collection types used directly with `Find<T>` and `FindAll<T>`.
 - Reused immutable source-generated activation metadata across readers, reducing
   the time and allocation cost of the first model lookup on a new reader.
+- Improved lookup performance.
 - Enabled trim, AOT, and single-file compatibility analysis.
 - Added the `MMDBSG001` through `MMDBSG016` diagnostics, which report model
   shapes the generator cannot support so that they are caught at build time


### PR DESCRIPTION
Fixes the data-section pointer fan-out denial of service (GHSA-hj94-g986-h9r7). A crafted database can nest pointers to shared targets so that decoding one record costs exponential time and memory from a small file. A recursion depth limit alone does not stop this, because the blow-up comes from width, not depth.

## Change

The decoder counts the values it decodes per lookup and rejects a database that exceeds 65,536, along with pointer cycles and over-deep data (depth limit 512), with an `InvalidDatabaseException`. A `StackOverflowException` is not catchable in .NET, so the explicit depth limit is required.

Guarding is done at container boundaries: each map and array charges its declared size against the budget and checks the depth, and each pointer follow checks the depth. Charging the declared size also rejects an oversized declared size before it is used as an allocation hint. The `Decoder` is shared across concurrent lookups, so the depth and value budget are threaded as method parameters rather than stored on the decoder, which keeps the decoder safe for concurrent reads with no thread-local access. The two guard helpers are aggressively inlined, so the normal-decode overhead stays near zero. The largest real records decode a few hundred values.

This matches the reader resource limits now recommended by the MaxMind DB specification (maxmind/MaxMind-DB#282).

Minor version bump (5.2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database decoding resilience by rejecting cyclic pointers, excessive nesting, and structures with excessive fan-out.
  * Added safeguards against oversized maps, unknown fields, and excessive string or binary payloads.
  * Enforced per-record processing and payload limits to reduce denial-of-service risks.
  * Invalid or resource-intensive data now consistently raises `InvalidDatabaseException`.

* **Documentation**
  * Added release notes describing the decoder protections introduced in version 5.2.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->